### PR TITLE
Initial very small amount of code moved from internal repo, with very basic pipeline, to begin getting CI/CD to work before bringing in the important code.

### DIFF
--- a/build/SizeBench-BuildAndTest-Job.yml
+++ b/build/SizeBench-BuildAndTest-Job.yml
@@ -1,0 +1,22 @@
+parameters:
+  packageMSIX: false
+  packageNuGets: false
+  publishNuGets: false
+
+jobs:
+- job: BuildJob
+  displayName: Build and Test
+  timeoutInMinutes: 60
+  strategy:
+    maxParallel: 2
+    matrix:
+      Release:
+        buildConfiguration: Release
+      Debug:
+        buildConfiguration: Debug
+  steps:
+  - template: ./SizeBench-BuildAndTest-Steps.yml
+    parameters:
+      packageMSIX: ${{parameters.packageMSIX}}
+      packageNuGets: ${{parameters.packageNuGets}}
+      publishNuGets: ${{parameters.publishNuGets}}

--- a/build/SizeBench-BuildAndTest-Steps.yml
+++ b/build/SizeBench-BuildAndTest-Steps.yml
@@ -1,0 +1,112 @@
+parameters:
+  packageMSIX: false
+  packageNuGets: false
+  publishNuGets: false
+  runTests: true
+
+steps:
+- task: PowerShell@2
+  displayName: 'Establish version number'
+  inputs:
+    targetType: inline
+    script: |
+      $versionMinor = $(pipelineYearMonth)
+      Write-Host Setting versionMinor variable to $versionMinor
+      Write-Host "##vso[task.setvariable variable=versionMinor]$versionMinor"
+      $versionPatch = ([Int32]::Parse("$(pipelineDay)").ToString()) + ([Int32]::Parse("$(revision)").ToString("00"))
+      Write-Host Setting versionPatch variable to $versionPatch
+      Write-Host "##vso[task.setvariable variable=versionPatch]$versionPatch"
+      $versionRelease = "$(versionMajor)" + "." + "$versionMinor" + "." + "$versionPatch" + ".0"
+      Write-Host Setting versionRelease variable to $versionRelease
+      Write-Host "##vso[task.setvariable variable=versionRelease]$versionRelease"
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 6 SDK'
+  inputs:
+    packageType: sdk
+    version: 6.x
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet restore'
+  inputs:
+    command: restore
+    feedsToUse: config
+    nugetConfigPath: NuGet.config
+    verbosityRestore: 'minimal'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet restore R2R'
+  inputs:
+    command: restore
+    restoreArguments: '/p:PublishReadyToRun=true'
+    feedsToUse: config
+    nugetConfigPath: NuGet.config
+    verbosityRestore: 'minimal'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build'
+  inputs:
+    projects: '**/*.csproj'
+    arguments: '--no-restore --configuration $(buildConfiguration) -p:Version=$(versionRelease)'
+
+
+- ${{ if eq(parameters.runTests, true) }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet --list-runtimes'
+    inputs:
+      command: custom
+      custom: '--list-runtimes'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet --list-sdks'
+    inputs:
+      command: custom
+      custom: '--list-sdks'
+
+  # 'dotnet test --blame-crash' requires procdump.exe to capture full dumps of native crashes.
+  # We need this because the tests can crash sometimes and this is the only way I've found to get a dump out to debug from the pipeline.
+  - task: PowerShell@2
+    displayName: 'Install ProcDump'
+    inputs:
+      targetType: inline
+      script: |
+        # Install Procdump
+        Write-Host "Starting ProcDump install to capture test crashes if they happen"
+        if (-Not (Test-Path "$(Agent.TempDirectory)\procdump")) {
+          Write-Host "Creating directory $(Agent.TempDirectory)\procdump"
+          mkdir "$(Agent.TempDirectory)\procdump"
+          Invoke-WebRequest -UserAgent wget -Uri https://download.sysinternals.com/files/Procdump.zip -OutFile "$(Agent.TempDirectory)\procdump\procdump.zip"
+          Expand-Archive -LiteralPath "$(Agent.TempDirectory)\procdump\procdump.zip" -DestinationPath "$(Agent.TempDirectory)\procdump"
+        }
+        Write-Host "Setting PROCDUMP_PATH to $(Agent.TempDirectory)\procdump"
+        Write-Host "##vso[task.setvariable variable=PROCDUMP_PATH]$(Agent.TempDirectory)\procdump"
+        Write-Host "Setting VSTEST_DUMP_FORCEPROCDUMP=1 to ensure native crash dumps are collected"
+        Write-Host "##vso[task.setvariable variable=VSTEST_DUMP_FORCEPROCDUMP]1"
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet test'
+    inputs:
+      command: test
+      projects: '**/*.csproj'
+      arguments: '--no-restore --configuration $(buildConfiguration) --blame-crash --settings RunSettings.runsettings $(codeCoverageArgs)'
+      testRunTitle: 'Tests for $(buildConfiguration)'
+      publishTestResults: true
+  
+
+
+- task: CopyFiles@2
+  displayName: 'Copy failure dumps'
+  condition: failed()
+  inputs:
+    sourceFolder: '$(Agent.TempDirectory)'
+    contents: '**\*.dmp'
+    targetFolder: '$(Build.ArtifactStagingDirectory)\failure-dumps'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: drop'
+  condition: or(failed(), eq(variables['buildConfiguration'], 'Release'))
+  inputs:
+    artifactName: 'drop'
+    parallel: true
+    pathToPublish: $(Build.ArtifactStagingDirectory)

--- a/build/SizeBench-CI.yml
+++ b/build/SizeBench-CI.yml
@@ -1,0 +1,18 @@
+trigger:
+- master
+
+variables:
+- template: ./SizeBench-Variables.yml
+
+pool:
+  name: Azure Pipelines
+  vmImage: 'windows-2022'
+  
+name: 'SizeBench_$(versionMajor).$(pipelineYearMonth).$(pipelineDay)_$(revision)'
+
+jobs:
+  - template: ./SizeBench-BuildAndTest-Job.yml
+    parameters:
+      packageMSIX: false
+      packageNugets: false
+      publishNugets: false

--- a/build/SizeBench-Variables.yml
+++ b/build/SizeBench-Variables.yml
@@ -1,0 +1,11 @@
+variables:
+  versionMajor: 2
+  revision: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 0)]
+  pipelineYearMonth: $[format('{0:yyMM}', pipeline.startTime)]
+  pipelineDay: $[format('{0:dd}', pipeline.startTime)]
+  buildPlatform: 'x64'
+  buildConfiguration: Release
+
+  # To enable code coverage in the pipelines, use this:
+  # codeCoverageArgs: '--collect "Code coverage"'
+  codeCoverageArgs: ''

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,56 @@
+<!-- This contains common things shared among all projects in the SizeBench repo -->
+
+<Project>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>DEBUG</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Assembly Attributes -->
+  <PropertyGroup>
+    <Company>Microsoft Corporation</Company>
+    <Product>SizeBench</Product>
+    <Copyright>Copyright ©  2015-2022</Copyright>
+    <AssemblyTitle>SizeBench</AssemblyTitle>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)\RunSettings.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+  
+  <!-- All of this applies only to the .NET code, and packaging of the app -->
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.csproj' Or '$(MSBuildProjectExtension)'=='.wapproj'">
+    <TargetFramework>net6.0-windows10.0.17763</TargetFramework>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+
+    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- This is necessary for the VS profiler to work, it can't seem to load symbols when this is set to 'embedded' -->
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="System"/>
+    <Using Include="System.Collections.Generic"/>
+    <Using Include="System.Linq"/>
+    <Using Include="System.Threading"/>
+    <Using Include="System.Threading.Tasks"/>
+  </ItemGroup>
+    
+  <!--
+    Deterministic build support for Source Link, which should only be done during CI builds.  TF_BUILD is set in Azure DevOps Pipelines.
+    See this blog post: https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
+  -->
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
+  </ItemGroup>
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,53 @@
+<!-- This contains common things shared among all projects in the SizeBench repo -->
+
+<Project>
+  <!-- These properties apply to both product and test code -->
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    
+    <!-- Below this, in this PropertyGroup, is all about Code Analysis -->
+    <AnalysisLevel>6</AnalysisLevel> <!-- Update this when upgrading from net6 -->
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+
+
+
+  <!-- These properties and items apply only to product code. -->
+  <ItemGroup Condition="'$(SizeBenchTestCode)'!='true'">
+    <!-- Enable SourceLink for product code only (don't need it for tests) -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+  </ItemGroup>
+
+
+
+  <!-- These properties and items apply only to C# test code. -->
+  <PropertyGroup Condition="'$(SizeBenchTestCode)'=='true' And '$(MSBuildProjectExtension)'=='.csproj'">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(SizeBenchTestCode)'=='true' And '$(MSBuildProjectExtension)'=='.csproj'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(SizeBenchTestCode)'=='true'">
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting"/>
+    <Using Include="Moq"/>
+  </ItemGroup>
+
+
+
+
+  <!-- Embed the git hash in the assembly informational version -->
+  <Target Name="InitializeSourceControlInformation" BeforeTargets="AddSourceRevisionToInformationalVersion">
+    <Exec
+      Command="git describe --long --always --dirty --exclude=* --abbrev=8"
+      ConsoleToMSBuild="True"
+      IgnoreExitCode="False"
+      >
+      <Output PropertyName="SourceRevisionId" TaskParameter="ConsoleOutput"/>
+    </Exec>
+  </Target>
+</Project>

--- a/src/SizeBench.LocalBuild/LocalBuildPathLocator.cs
+++ b/src/SizeBench.LocalBuild/LocalBuildPathLocator.cs
@@ -1,0 +1,43 @@
+﻿using System.IO;
+using SizeBench.PathLocators;
+
+namespace SizeBench.LocalBuild;
+
+public class LocalBuildPathLocator : IBinaryLocator
+{
+    public bool TryInferBinaryPathFromPDBPath(string pdbPath, out string binaryPath)
+    {
+        if (pdbPath is null)
+        {
+            binaryPath = String.Empty;
+            return false;
+        }
+
+        string[] extensionsSupported = { "dll", "exe", "efi", "sys", "pyd" };
+        foreach (var extension in extensionsSupported)
+        {
+            var possibleBinaryPath = Path.ChangeExtension(pdbPath, extension);
+            if (File.Exists(possibleBinaryPath))
+            {
+                binaryPath = possibleBinaryPath;
+                return true;
+            }
+        }
+
+        // Clang seems to build PDBs with names like "msedge.dll.pdb" by just appending .pdb to the filename,
+        // so let's recognize that style too.
+        var lastIndexOfDotPdb = pdbPath.LastIndexOf(".pdb", StringComparison.OrdinalIgnoreCase);
+        if (lastIndexOfDotPdb > 0)
+        {
+            var clangPossibleBinaryPath = pdbPath.Remove(lastIndexOfDotPdb);
+            if (clangPossibleBinaryPath != pdbPath && File.Exists(clangPossibleBinaryPath))
+            {
+                binaryPath = clangPossibleBinaryPath;
+                return true;
+            }
+        }
+
+        binaryPath = String.Empty;
+        return false;
+    }
+}

--- a/src/SizeBench.LocalBuild/Properties/AssemblyInfo.cs
+++ b/src/SizeBench.LocalBuild/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: CLSCompliant(true)]

--- a/src/SizeBench.LocalBuild/SizeBench.LocalBuild.csproj
+++ b/src/SizeBench.LocalBuild/SizeBench.LocalBuild.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<PackageReference Include="Castle.Windsor" Version="5.1.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\SizeBench.PathLocators\SizeBench.PathLocators.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/SizeBench.PathLocators/IBinaryLocator.cs
+++ b/src/SizeBench.PathLocators/IBinaryLocator.cs
@@ -1,0 +1,6 @@
+﻿namespace SizeBench.PathLocators;
+
+public interface IBinaryLocator
+{
+    bool TryInferBinaryPathFromPDBPath(string pdbPath, out string binaryPath);
+}

--- a/src/SizeBench.PathLocators/Properties/AssemblyInfo.cs
+++ b/src/SizeBench.PathLocators/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: CLSCompliant(true)]

--- a/src/SizeBench.PathLocators/SizeBench.PathLocators.csproj
+++ b/src/SizeBench.PathLocators/SizeBench.PathLocators.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/SizeBench.sln
+++ b/src/SizeBench.sln
@@ -1,0 +1,51 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32210.238
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SizeBench.PathLocators", "SizeBench.PathLocators\SizeBench.PathLocators.csproj", "{8DC65B1C-73E7-4115-BEF9-A4E2BB227BBD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PathLocators", "PathLocators", "{42A14DC3-4E12-43EA-BA1F-4A3AA3176624}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F280E6E5-6895-4ABC-ACB5-0015D2E7C70B}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SizeBench.LocalBuild", "SizeBench.LocalBuild\SizeBench.LocalBuild.csproj", "{F1FED405-1C77-4DF1-A8C7-1FB85496271F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{48871072-BBA3-4232-AB7E-6A204F4109C9}"
+	ProjectSection(SolutionItems) = preProject
+		..\build\SizeBench-BuildAndTest-Job.yml = ..\build\SizeBench-BuildAndTest-Job.yml
+		..\build\SizeBench-BuildAndTest-Steps.yml = ..\build\SizeBench-BuildAndTest-Steps.yml
+		..\build\SizeBench-CI.yml = ..\build\SizeBench-CI.yml
+		..\build\SizeBench-Variables.yml = ..\build\SizeBench-Variables.yml
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8DC65B1C-73E7-4115-BEF9-A4E2BB227BBD}.Debug|x64.ActiveCfg = Debug|x64
+		{8DC65B1C-73E7-4115-BEF9-A4E2BB227BBD}.Debug|x64.Build.0 = Debug|x64
+		{8DC65B1C-73E7-4115-BEF9-A4E2BB227BBD}.Release|x64.ActiveCfg = Release|Any CPU
+		{8DC65B1C-73E7-4115-BEF9-A4E2BB227BBD}.Release|x64.Build.0 = Release|Any CPU
+		{F1FED405-1C77-4DF1-A8C7-1FB85496271F}.Debug|x64.ActiveCfg = Debug|x64
+		{F1FED405-1C77-4DF1-A8C7-1FB85496271F}.Debug|x64.Build.0 = Debug|x64
+		{F1FED405-1C77-4DF1-A8C7-1FB85496271F}.Release|x64.ActiveCfg = Release|x64
+		{F1FED405-1C77-4DF1-A8C7-1FB85496271F}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8DC65B1C-73E7-4115-BEF9-A4E2BB227BBD} = {42A14DC3-4E12-43EA-BA1F-4A3AA3176624}
+		{F1FED405-1C77-4DF1-A8C7-1FB85496271F} = {42A14DC3-4E12-43EA-BA1F-4A3AA3176624}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {936F9790-BC54-416C-9C26-BB58BA16D33E}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Why is this change being made?
Getting the repo stood up, getting a CI/CD pipeline started to begin iterating on.

## How was the change tested?
Will be tested when the CI/CD pipeline is actually run in ADO, which requires it to be committed first.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [ ] ~Changes have been validated~
* [ ] ~Documentation updated. Please add or update any docs in the repo as necessary.~