### PR TITLE
Error reporting code ported from internal repo.

### DIFF
--- a/src/SizeBench.ErrorReporting.Tests/ErrorInfoProviders/EnvironmentInfoProviderTests.cs
+++ b/src/SizeBench.ErrorReporting.Tests/ErrorInfoProviders/EnvironmentInfoProviderTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SizeBench.ErrorReporting.ErrorInfoProviders.Tests;
+
+[TestClass]
+public sealed class EnvironmentInfoProviderTests
+{
+    [ExpectedException(typeof(ArgumentNullException), AllowDerivedTypes = false)]
+    [TestMethod]
+    public void NullBodyThrows()
+    {
+        var provider = new EnvironmentInfoProvider();
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type. This test is intentionally testing null.
+        provider.AddErrorInfo(null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+
+    [TestMethod]
+    public void ImportantEnvironmentInformationIsPresent()
+    {
+        var provider = new EnvironmentInfoProvider();
+        var body = new StringBuilder();
+        provider.AddErrorInfo(body);
+        var output = body.ToString();
+
+        StringAssert.Contains(output, RuntimeInformation.FrameworkDescription, StringComparison.Ordinal);
+        StringAssert.Contains(output, RuntimeInformation.OSDescription, StringComparison.Ordinal);
+        StringAssert.Contains(output, $"OS Architecture: {RuntimeInformation.OSArchitecture}", StringComparison.Ordinal);
+        StringAssert.Contains(output, $"Process Architecture: {RuntimeInformation.ProcessArchitecture}", StringComparison.Ordinal);
+        StringAssert.Contains(output, $"Locale: {CultureInfo.CurrentCulture}", StringComparison.Ordinal);
+        StringAssert.Contains(output, $"UI Locale: {CultureInfo.CurrentUICulture}", StringComparison.Ordinal);
+    }
+}

--- a/src/SizeBench.ErrorReporting.Tests/ErrorInfoProviders/ExceptionInfoProviderTests.cs
+++ b/src/SizeBench.ErrorReporting.Tests/ErrorInfoProviders/ExceptionInfoProviderTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Text;
+
+namespace SizeBench.ErrorReporting.ErrorInfoProviders.Tests;
+
+[TestClass]
+public class ExceptionInfoProviderTests
+{
+    [ExpectedException(typeof(ArgumentNullException), AllowDerivedTypes = false)]
+    [TestMethod]
+    public void NullBodyThrows()
+    {
+        var provider = new ExceptionInfoProvider(new InvalidOperationException("test"));
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.  This test is intentionally testing null.
+        provider.AddErrorInfo(null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+
+    [TestMethod]
+    public void EntriesContainUsefulExceptionData()
+    {
+        var innerExceptionMessage = "inner exception for ExceptionInfoProvider";
+        var outerExceptionMessage = "This is a test exception for ExceptionInfoProvider";
+
+        Exception testException;
+        try
+        {
+            try
+            {
+                throw new ArithmeticException(innerExceptionMessage);
+            }
+            catch (Exception innerException)
+            {
+                throw new InvalidOperationException(outerExceptionMessage, innerException);
+            }
+        }
+        catch (Exception ex)
+        {
+            testException = ex;
+        }
+
+        var provider = new ExceptionInfoProvider(testException);
+        var bodySB = new StringBuilder(1000);
+        provider.AddErrorInfo(bodySB);
+        var body = bodySB.ToString();
+
+        StringAssert.Contains(body, $"\t{typeof(ArithmeticException).FullName}: {innerExceptionMessage}", StringComparison.Ordinal);
+        StringAssert.Contains(body, $"{typeof(InvalidOperationException).FullName}: {outerExceptionMessage}", StringComparison.Ordinal);
+    }
+}

--- a/src/SizeBench.ErrorReporting.Tests/ErrorInfoProviders/ProcessInfoProviderTests.cs
+++ b/src/SizeBench.ErrorReporting.Tests/ErrorInfoProviders/ProcessInfoProviderTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics;
+using System.Text;
+
+namespace SizeBench.ErrorReporting.ErrorInfoProviders.Tests;
+
+[TestClass]
+public sealed class ProcessInfoProviderTests
+{
+    [ExpectedException(typeof(ArgumentNullException), AllowDerivedTypes = false)]
+    [TestMethod]
+    public void NullBodyThrows()
+    {
+        var provider = new ProcessInfoProvider();
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.  This test is intentionally testing null
+        provider.AddErrorInfo(null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+
+    [TestMethod]
+    public void ImportantProcessInformationIsPresent()
+    {
+        var provider = new ProcessInfoProvider();
+        var body = new StringBuilder();
+        provider.AddErrorInfo(body);
+        var output = body.ToString();
+
+        StringAssert.Contains(output, Environment.CommandLine, StringComparison.Ordinal);
+        StringAssert.Contains(output, Process.GetCurrentProcess().ProcessName, StringComparison.Ordinal);
+        StringAssert.Contains(output, $"64-bit Process: {Environment.Is64BitProcess}", StringComparison.Ordinal);
+    }
+}

--- a/src/SizeBench.ErrorReporting.Tests/ErrorReportTests.cs
+++ b/src/SizeBench.ErrorReporting.Tests/ErrorReportTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Text;
+using SizeBench.ErrorReporting.ErrorInfoProviders;
+
+namespace SizeBench.ErrorReporting.Tests;
+
+[TestClass]
+public class ErrorReportTests
+{
+    internal class TestErrorInfoProvider : IErrorInfoProvider
+    {
+        public string Info { get; set; } = String.Empty;
+
+        public void AddErrorInfo(StringBuilder body) => body.Append(this.Info);
+    }
+
+    [TestMethod]
+    public void NullParametersThrow()
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type. This test is intentionally testing null.
+        Assert.ThrowsException<ArgumentNullException>(() => ErrorReport.GetErrorInfo(null, new List<IErrorInfoProvider>()));
+        Assert.ThrowsException<ArgumentNullException>(() => ErrorReport.GetErrorInfo(new InvalidOperationException("test"), null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+
+    [TestMethod]
+    public void InfoProvidersGetAppendedToErrorDetails()
+    {
+        var testErrorInfoProvider = new TestErrorInfoProvider() { Info = "This is a\ntest error info provider\n\nwith newlines." };
+        InvalidOperationException? caughtException;
+        try
+        {
+            throw new InvalidOperationException("Test exception message");
+        }
+        catch (InvalidOperationException ex)
+        {
+            caughtException = ex;
+        }
+
+        var errorInfo = ErrorReport.GetErrorInfo(caughtException, new List<IErrorInfoProvider>()
+            {
+                testErrorInfoProvider
+            });
+
+        StringAssert.Contains(errorInfo, testErrorInfoProvider.Info, StringComparison.Ordinal);
+        StringAssert.Contains(errorInfo, caughtException.Hash(), StringComparison.Ordinal);
+    }
+}

--- a/src/SizeBench.ErrorReporting.Tests/ExceptionHashExtensionsTests.cs
+++ b/src/SizeBench.ErrorReporting.Tests/ExceptionHashExtensionsTests.cs
@@ -1,0 +1,50 @@
+﻿namespace SizeBench.ErrorReporting.Tests;
+
+[TestClass]
+public class ExceptionHashExtensionsTests
+{
+#nullable disable // Intentionally testing passing null to test this case
+    [TestMethod]
+    public void NullExceptionThrows()
+    {
+        var exceptionThrown = true;
+        try
+        {
+            ExceptionHashExtensions.Hash(null);
+        }
+        catch (ArgumentNullException e)
+        {
+            Assert.AreEqual("ex", e.ParamName);
+        }
+
+        Assert.IsTrue(exceptionThrown);
+    }
+#nullable enable
+
+    [TestMethod]
+    public void ExceptionsFromDifferentCallsitesGenerateDifferentHashes()
+    {
+        var innerException = new Exception("innerException");
+        string hash1;
+        try
+        {
+            throw new Exception("Exception", innerException);
+        }
+        catch (Exception e)
+        {
+            hash1 = e.Hash();
+        }
+
+        string hash2;
+        try
+        {
+            throw new Exception("Exception", innerException);
+        }
+        catch (Exception e)
+        {
+            hash2 = e.Hash();
+        }
+
+        Assert.AreNotEqual(hash1, hash2);
+    }
+}

--- a/src/SizeBench.ErrorReporting.Tests/GlobalSuppressions.cs
+++ b/src/SizeBench.ErrorReporting.Tests/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Not important for test code.")]
+[assembly: SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Not important for test code")]

--- a/src/SizeBench.ErrorReporting.Tests/Properties/AssemblyInfo.cs
+++ b/src/SizeBench.ErrorReporting.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: CLSCompliant(false)]

--- a/src/SizeBench.ErrorReporting.Tests/SizeBench.ErrorReporting.Tests.csproj
+++ b/src/SizeBench.ErrorReporting.Tests/SizeBench.ErrorReporting.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <SizeBenchTestCode>true</SizeBenchTestCode>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SizeBench.AsyncInfrastructure\SizeBench.AsyncInfrastructure.csproj" />
+        <ProjectReference Include="..\SizeBench.ErrorReporting\SizeBench.ErrorReporting.csproj" />
+        <ProjectReference Include="..\SizeBench.Logging\SizeBench.Logging.csproj" />
+        <ProjectReference Include="..\SizeBench.TestInfrastructure\SizeBench.TestInfrastructure.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/SizeBench.ErrorReporting.Tests/TestingTheTests.cs
+++ b/src/SizeBench.ErrorReporting.Tests/TestingTheTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Reflection;
+
+namespace SizeBench.ErrorReporting.Tests;
+
+[TestClass]
+public sealed class TestingTheTests
+{
+    // Yo dawg, I heard you like testing, so now I'm gonna test your tests.
+    // But for real, this is a protection against some stupid mistakes made in testing in the past where test classes were marked as "internal"
+    // which silently prevents them from running in MSTest.  It's never expected that someone would go to the work of writing a test class only
+    // to have it not run - so if we find any tests marked as internal, fail this test to signal that there's problems elsewhere.
+
+    [TestMethod]
+    public void InternalTestClassesShouldNotExist()
+    {
+        var allTypes = typeof(TestingTheTests).Assembly.GetTypes();
+        foreach (var type in allTypes)
+        {
+            if (type.GetCustomAttribute<TestClassAttribute>() != null)
+            {
+                if (type.IsNotPublic)
+                {
+                    Assert.Fail($"The class {type.Name} is not public, but it is marked as [TestClass].  This prevents MSTest from running the tests inside it, and you surely didn't mean to do that - make the type public.");
+                }
+            }
+        }
+    }
+}

--- a/src/SizeBench.ErrorReporting/ErrorInfoProviders/EnvironmentInfoProvider.cs
+++ b/src/SizeBench.ErrorReporting/ErrorInfoProviders/EnvironmentInfoProvider.cs
@@ -1,0 +1,35 @@
+﻿using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace SizeBench.ErrorReporting.ErrorInfoProviders;
+
+public sealed class EnvironmentInfoProvider : KeyValueInfoProvider
+{
+    public EnvironmentInfoProvider() : base("Environment Information")
+    {
+    }
+
+    public override Dictionary<string, string> GetEntries()
+    {
+        var entries = new Dictionary<string, string>()
+            {
+                { "Processor Count", Environment.ProcessorCount.ToString(CultureInfo.InvariantCulture.NumberFormat) },
+                { "OS Version", Environment.OSVersion.ToString() },
+                { "Runtime Version", Environment.Version.ToString() },
+                { "Framework Description", RuntimeInformation.FrameworkDescription },
+                { "CoreCLR Build", ((AssemblyInformationalVersionAttribute[])typeof(object).Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute),false))[0].InformationalVersion.Split('+')[0] },
+                { "CoreCLR Hash", ((AssemblyInformationalVersionAttribute[])typeof(object).Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false))[0].InformationalVersion.Split('+')[1] },
+                { "CoreFX Build", ((AssemblyInformationalVersionAttribute[])typeof(Uri).Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute),false))[0].InformationalVersion.Split('+')[0] },
+                { "CoreFX Hash", ((AssemblyInformationalVersionAttribute[])typeof(Uri).Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute),false))[0].InformationalVersion.Split('+')[1] },
+                { "OS Description", RuntimeInformation.OSDescription },
+                { "OS Architecture", RuntimeInformation.OSArchitecture.ToString() },
+                { "Process Architecture", RuntimeInformation.ProcessArchitecture.ToString() },
+                { "Has Shutdown Started", Environment.HasShutdownStarted.ToString(CultureInfo.InvariantCulture) },
+                { "Current Directory", Environment.CurrentDirectory },
+                { "Locale", CultureInfo.CurrentCulture.ToString() },
+                { "UI Locale", CultureInfo.CurrentUICulture.ToString() },
+            };
+        return entries;
+    }
+}

--- a/src/SizeBench.ErrorReporting/ErrorInfoProviders/ExceptionInfoProvider.cs
+++ b/src/SizeBench.ErrorReporting/ErrorInfoProviders/ExceptionInfoProvider.cs
@@ -1,0 +1,22 @@
+﻿using System.Text;
+using SizeBench.Logging;
+
+namespace SizeBench.ErrorReporting.ErrorInfoProviders;
+
+public sealed class ExceptionInfoProvider : IErrorInfoProvider
+{
+    private readonly Exception _exception;
+
+    public ExceptionInfoProvider(Exception ex)
+    {
+        this._exception = ex ?? throw new ArgumentNullException(nameof(ex));
+    }
+
+    public void AddErrorInfo(StringBuilder body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        body.Append(this._exception.GetFormattedTextForLogging("Exception information:", "\n"));
+        body.Append(Environment.NewLine);
+    }
+}

--- a/src/SizeBench.ErrorReporting/ErrorInfoProviders/IErrorInfoProvider.cs
+++ b/src/SizeBench.ErrorReporting/ErrorInfoProviders/IErrorInfoProvider.cs
@@ -1,0 +1,8 @@
+﻿using System.Text;
+
+namespace SizeBench.ErrorReporting.ErrorInfoProviders;
+
+public interface IErrorInfoProvider
+{
+    void AddErrorInfo(StringBuilder body);
+}

--- a/src/SizeBench.ErrorReporting/ErrorInfoProviders/KeyValueInfoProvider.cs
+++ b/src/SizeBench.ErrorReporting/ErrorInfoProviders/KeyValueInfoProvider.cs
@@ -1,0 +1,30 @@
+﻿using System.Globalization;
+using System.Text;
+
+namespace SizeBench.ErrorReporting.ErrorInfoProviders;
+
+public abstract class KeyValueInfoProvider : IErrorInfoProvider
+{
+    private readonly string _title;
+
+    internal KeyValueInfoProvider(string title)
+    {
+        this._title = title;
+    }
+
+    public void AddErrorInfo(StringBuilder body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+
+        body.Append(this._title);
+        body.Append(Environment.NewLine);
+
+        foreach (var entry in GetEntries())
+        {
+            body.AppendFormat(CultureInfo.InvariantCulture, "{0}: {1}", entry.Key, entry.Value);
+            body.Append(Environment.NewLine);
+        }
+    }
+
+    public abstract Dictionary<string, string> GetEntries();
+}

--- a/src/SizeBench.ErrorReporting/ErrorInfoProviders/ProcessInfoProvider.cs
+++ b/src/SizeBench.ErrorReporting/ErrorInfoProviders/ProcessInfoProvider.cs
@@ -1,0 +1,51 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+
+namespace SizeBench.ErrorReporting.ErrorInfoProviders;
+
+public sealed class ProcessInfoProvider : KeyValueInfoProvider
+{
+    public ProcessInfoProvider() : base("Process Information")
+    {
+    }
+
+    public override Dictionary<string, string> GetEntries()
+    {
+        var appVersion = String.Empty;
+        var appHash = String.Empty;
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (null != entryAssembly)
+        {
+            var informationalVersionAttributes = (AssemblyInformationalVersionAttribute[])entryAssembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
+            if (informationalVersionAttributes.Length > 0)
+            {
+                var informationalVersionParts = informationalVersionAttributes[0].InformationalVersion.Split('+');
+                if (informationalVersionParts.Length > 0)
+                {
+                    appVersion = informationalVersionParts[0];
+                    if (informationalVersionParts.Length > 1)
+                    {
+                        appHash = informationalVersionParts[1];
+                    }
+                }
+            }
+        }
+        string processName;
+        using (var currentProcess = Process.GetCurrentProcess())
+        {
+            processName = currentProcess.ProcessName;
+        }
+
+        var entries = new Dictionary<string, string>() {
+                { "Process Name", processName },
+                { "Application Version", appVersion },
+                { "Application Hash", appHash },
+                {"Working Set", Environment.WorkingSet.ToString("##,#", CultureInfo.InvariantCulture.NumberFormat) },
+                {"Command Line", Environment.CommandLine },
+                {"64-bit Process", Environment.Is64BitProcess.ToString(CultureInfo.InvariantCulture) },
+            };
+
+        return entries;
+    }
+}

--- a/src/SizeBench.ErrorReporting/ErrorReport.cs
+++ b/src/SizeBench.ErrorReporting/ErrorReport.cs
@@ -1,0 +1,33 @@
+﻿using System.Globalization;
+using System.Text;
+using SizeBench.ErrorReporting.ErrorInfoProviders;
+
+namespace SizeBench.ErrorReporting;
+
+public static class ErrorReport
+{
+    public static string GetErrorInfo(Exception ex, IEnumerable<IErrorInfoProvider> errorInfoProviders)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+        ArgumentNullException.ThrowIfNull(errorInfoProviders);
+
+        var exceptionHash = ex.Hash();
+        var body = new StringBuilder(10000);
+        ProcessInfoProviders(body, errorInfoProviders);
+        body.AppendFormat(CultureInfo.InvariantCulture, "\n\n\nExtended Case #{0}", exceptionHash);
+
+        return body.ToString();
+    }
+
+    private static void ProcessInfoProviders(StringBuilder body, IEnumerable<IErrorInfoProvider> errorInfoProviders)
+    {
+        foreach (var infoProvider in errorInfoProviders)
+        {
+            infoProvider.AddErrorInfo(body);
+
+            // Separate the providers from each other
+            body.Append(Environment.NewLine);
+            body.Append(Environment.NewLine);
+        }
+    }
+}

--- a/src/SizeBench.ErrorReporting/ExceptionHashExtensions.cs
+++ b/src/SizeBench.ErrorReporting/ExceptionHashExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SizeBench.ErrorReporting;
+
+public static class ExceptionHashExtensions
+{
+    public static string Hash(this Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+        var stringBuilder = new StringBuilder(100);
+        stringBuilder.AppendLine(ex.GetType().FullName);
+        for (var innerException = ex.InnerException; innerException != null; innerException = innerException.InnerException)
+        {
+            stringBuilder.AppendLine(innerException.GetType().FullName);
+        }
+        if (ex.TargetSite != null)
+        {
+            stringBuilder.AppendLine(ex.TargetSite.Name);
+        }
+
+        stringBuilder.AppendLine(ex.Source);
+        stringBuilder.AppendLine(ex.HelpLink);
+        stringBuilder.AppendLine(ex.StackTrace);
+
+        return CalculateMD5(stringBuilder.ToString());
+    }
+
+    private static string CalculateMD5(string textToHash)
+    {
+        var stringBuilder = new StringBuilder(32);
+#pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms - this isn't used for any security purpose, just to bucket errors for diagnostics
+        using (var md5 = MD5.Create())
+#pragma warning restore CA5351 // Do Not Use Broken Cryptographic Algorithms
+        {
+            var bytes = Encoding.ASCII.GetBytes(textToHash);
+            var array = md5.ComputeHash(bytes);
+            for (var i = 0; i < array.Length; i++)
+            {
+                stringBuilder.Append(array[i].ToString("X2", CultureInfo.InvariantCulture.NumberFormat));
+            }
+        }
+        return stringBuilder.ToString();
+    }
+}

--- a/src/SizeBench.ErrorReporting/GlobalSuppressions.cs
+++ b/src/SizeBench.ErrorReporting/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+[assembly: SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase",
+                           Justification = "SizeBench never uses ToLowerInvariant for security purposes, only for logging, where lowercase is easier on the eyes",
+                           Scope = "namespaceanddescendants", Target = "~N:SizeBench.ErrorReporting")]

--- a/src/SizeBench.ErrorReporting/Properties/AssemblyInfo.cs
+++ b/src/SizeBench.ErrorReporting/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: CLSCompliant(true)]
+[assembly: InternalsVisibleTo("SizeBench.ErrorReporting.Tests")]

--- a/src/SizeBench.ErrorReporting/SizeBench.ErrorReporting.csproj
+++ b/src/SizeBench.ErrorReporting/SizeBench.ErrorReporting.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+        <ProjectReference Include="..\SizeBench.Logging\SizeBench.Logging.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/SizeBench.sln
+++ b/src/SizeBench.sln
@@ -31,13 +31,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{5E7F622A
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{DDB4277D-5229-47F8-8A1C-576CA06F7D0D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SizeBench.AsyncInfrastructure", "SizeBench.AsyncInfrastructure\SizeBench.AsyncInfrastructure.csproj", "{F2EE1D2F-E908-4C6B-9A03-22E101F95882}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SizeBench.AsyncInfrastructure", "SizeBench.AsyncInfrastructure\SizeBench.AsyncInfrastructure.csproj", "{F2EE1D2F-E908-4C6B-9A03-22E101F95882}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SizeBench.Logging", "SizeBench.Logging\SizeBench.Logging.csproj", "{77B1C741-09A2-4C69-9CE9-CCC814104F2E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SizeBench.Logging", "SizeBench.Logging\SizeBench.Logging.csproj", "{77B1C741-09A2-4C69-9CE9-CCC814104F2E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SizeBench.Logging.Tests", "SizeBench.Logging.Tests\SizeBench.Logging.Tests.csproj", "{67AB8708-AC46-4AB4-BE88-AFEBBFF0798E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SizeBench.Logging.Tests", "SizeBench.Logging.Tests\SizeBench.Logging.Tests.csproj", "{67AB8708-AC46-4AB4-BE88-AFEBBFF0798E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SizeBench.TestInfrastructure", "SizeBench.TestInfrastructure\SizeBench.TestInfrastructure.csproj", "{97DCB2D9-F2C5-4342-B229-1708A11F0DD9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SizeBench.TestInfrastructure", "SizeBench.TestInfrastructure\SizeBench.TestInfrastructure.csproj", "{97DCB2D9-F2C5-4342-B229-1708A11F0DD9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SizeBench.ErrorReporting", "SizeBench.ErrorReporting\SizeBench.ErrorReporting.csproj", "{45FED563-6A30-4145-AB46-7D91FC6DA891}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SizeBench.ErrorReporting.Tests", "SizeBench.ErrorReporting.Tests\SizeBench.ErrorReporting.Tests.csproj", "{5158845A-13ED-484C-8B7B-555E503CDACF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +73,14 @@ Global
 		{97DCB2D9-F2C5-4342-B229-1708A11F0DD9}.Debug|x64.Build.0 = Debug|x64
 		{97DCB2D9-F2C5-4342-B229-1708A11F0DD9}.Release|x64.ActiveCfg = Release|x64
 		{97DCB2D9-F2C5-4342-B229-1708A11F0DD9}.Release|x64.Build.0 = Release|x64
+		{45FED563-6A30-4145-AB46-7D91FC6DA891}.Debug|x64.ActiveCfg = Debug|x64
+		{45FED563-6A30-4145-AB46-7D91FC6DA891}.Debug|x64.Build.0 = Debug|x64
+		{45FED563-6A30-4145-AB46-7D91FC6DA891}.Release|x64.ActiveCfg = Release|x64
+		{45FED563-6A30-4145-AB46-7D91FC6DA891}.Release|x64.Build.0 = Release|x64
+		{5158845A-13ED-484C-8B7B-555E503CDACF}.Debug|x64.ActiveCfg = Debug|x64
+		{5158845A-13ED-484C-8B7B-555E503CDACF}.Debug|x64.Build.0 = Debug|x64
+		{5158845A-13ED-484C-8B7B-555E503CDACF}.Release|x64.ActiveCfg = Release|x64
+		{5158845A-13ED-484C-8B7B-555E503CDACF}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -80,6 +92,8 @@ Global
 		{77B1C741-09A2-4C69-9CE9-CCC814104F2E} = {DDB4277D-5229-47F8-8A1C-576CA06F7D0D}
 		{67AB8708-AC46-4AB4-BE88-AFEBBFF0798E} = {DDB4277D-5229-47F8-8A1C-576CA06F7D0D}
 		{97DCB2D9-F2C5-4342-B229-1708A11F0DD9} = {5E7F622A-2164-45BD-94F2-682AD964C057}
+		{45FED563-6A30-4145-AB46-7D91FC6DA891} = {DDB4277D-5229-47F8-8A1C-576CA06F7D0D}
+		{5158845A-13ED-484C-8B7B-555E503CDACF} = {DDB4277D-5229-47F8-8A1C-576CA06F7D0D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {936F9790-BC54-416C-9C26-BB58BA16D33E}


### PR DESCRIPTION
## Why is this change being made?
Moving over the error reporting code as the next layer from the internal repo.

## How was the change tested?
Ran all the tests in VS Test Explorer.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* ~[ ] Documentation updated. Please add or update any docs in the repo as necessary.~