### PR TITLE
Create NuGet package for SKUCrawler

### DIFF
--- a/build/SizeBench-BuildAndTest-Job.yml
+++ b/build/SizeBench-BuildAndTest-Job.yml
@@ -1,6 +1,5 @@
 parameters:
   packageMSIX: false
-  packageNuGets: false
   publishNuGets: false
 
 jobs:
@@ -18,5 +17,4 @@ jobs:
   - template: ./SizeBench-BuildAndTest-Steps.yml
     parameters:
       packageMSIX: ${{parameters.packageMSIX}}
-      packageNuGets: ${{parameters.packageNuGets}}
       publishNuGets: ${{parameters.publishNuGets}}

--- a/build/SizeBench-BuildAndTest-Steps.yml
+++ b/build/SizeBench-BuildAndTest-Steps.yml
@@ -1,6 +1,5 @@
 parameters:
   packageMSIX: false
-  packageNuGets: false
   publishNuGets: false
   runTests: true
 
@@ -127,6 +126,27 @@ steps:
       script: |
         $Package = Get-ChildItem -Recurse -Path "$(Build.ArtifactStagingDirectory)\MSIX\$(buildConfiguration)" -Filter "SizeBench.GUI*.appx"
         .\build\Test-SizeBenchPackage.ps1 -Verbose -Path $Package.FullName
+
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish SKUCrawler'
+  condition: and(succeeded(), eq(variables['buildConfiguration'], 'Release'))
+  inputs:
+    command: publish
+    publishWebProjects: false
+    modifyOutputPath: false
+    zipAfterPublish: false
+    projects: 'src\SizeBench.SKUCrawler\SizeBench.SKUCrawler.csproj'
+    arguments: '-c $(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack SKUCrawler'
+  condition: and(succeeded(), eq(variables['buildConfiguration'], 'Release'))
+  inputs:
+    command: custom
+    projects: 'src\SizeBench.SKUCrawler\SizeBench.SKUCrawler.csproj'
+    custom: pack
+    arguments: '--no-build --output "$(Build.ArtifactStagingDirectory)\NuGets" /p:Configuration=$(BuildConfiguration) /p:PackageVersion=$(versionRelease)'
 
 
 - task: CopyFiles@2

--- a/build/SizeBench-CI.yml
+++ b/build/SizeBench-CI.yml
@@ -14,5 +14,4 @@ jobs:
   - template: ./SizeBench-BuildAndTest-Job.yml
     parameters:
       packageMSIX: true
-      packageNugets: false
       publishNugets: false

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,8 +9,9 @@
   <PropertyGroup>
     <Company>Microsoft Corporation</Company>
     <Product>SizeBench</Product>
-    <Copyright>Copyright ©  2015-2022</Copyright>
+    <Copyright>Copyright ©  2015-2023</Copyright>
     <AssemblyTitle>SizeBench</AssemblyTitle>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,17 +23,9 @@
     <TargetFramework>net6.0-windows10.0.17763</TargetFramework>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>
+    <Platform>x64</Platform>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
-
-    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-
-    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-
-    <!-- This is necessary for the VS profiler to work, it can't seem to load symbols when this is set to 'embedded' -->
-    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -41,16 +34,5 @@
     <Using Include="System.Linq"/>
     <Using Include="System.Threading"/>
     <Using Include="System.Threading.Tasks"/>
-  </ItemGroup>
-    
-  <!--
-    Deterministic build support for Source Link, which should only be done during CI builds.  TF_BUILD is set in Azure DevOps Pipelines.
-    See this blog post: https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
-  -->
-  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-  <ItemGroup>
-    <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -16,8 +16,14 @@
 
   <!-- These properties and items apply only to product code. -->
   <ItemGroup Condition="'$(SizeBenchTestCode)'!='true'">
-    <!-- Enable SourceLink for product code only (don't need it for tests) -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 
@@ -46,7 +52,7 @@
 
 
   <!-- This is all the stuff necessary to use DbgX at runtime, it's needed in multiple projects, so it's centralized here -->
-  <ItemGroup Condition="'$(IncludeDbgXAssets)'=='true'">
+  <ItemGroup Condition="'$(IncludeDbgXAssets)'=='true' and '$(MicrosoftDebuggingDataModelDbgModelApiXtnPath)' != ''">
     <Content Include="..\ExternalDependencies\DIA\msdia140.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/SizeBench.SKUCrawler/SizeBench.SKUCrawler.csproj
+++ b/src/SizeBench.SKUCrawler/SizeBench.SKUCrawler.csproj
@@ -3,8 +3,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IncludeDbgXAssets>true</IncludeDbgXAssets>
+    <IsPackable>true</IsPackable>
     <StartupObject>SizeBench.SKUCrawler.Program</StartupObject>
-    <PublishProfile>Properties\PublishProfiles\WinX64.pubxml</PublishProfile>
+      
+    <!-- Publishing Properties-->
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <PublishDir>bin\$(Platform)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
+    <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SizeBench.SKUCrawler/SizeBench.SKUCrawler.nuspec
+++ b/src/SizeBench.SKUCrawler/SizeBench.SKUCrawler.nuspec
@@ -5,9 +5,9 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>SizeBenchTeam@microsoft.com</owners>
-    <projectUrl>https://msblox.visualstudio.com/SizeBench</projectUrl>
+    <projectUrl>https://github.com/microsoft/SizeBench</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The SizeBench SKUCrawler is a tool to crawl through a folder or Windows SKU, collecting up a SQLite database with interesting data about binary size.</description>
+    <description>The SizeBench SKUCrawler is a tool to crawl through a folder, collecting up a SQLite database with interesting data about binary size.</description>
     <copyright>Microsoft Corp</copyright>
   </metadata>
   <files>


### PR DESCRIPTION
## Why is this change being made?
The SizeBench SKUCrawler tool is the first thing that'll get NuGet packaged, though other packages will come later to this repo.  This PR aims to get the `nupkg` file built in the CI pipeline, but does not push it to any feed currently.

## Briefly summarize what changed
Added the build of the NuGet package to the pipeline, and simplified some of how deterministic builds are done now that I know `DotNet.ReproducibleBuilds` exists.

While in here I'm also coincidentally fixing #18 

## How was the change tested?
Manually ran the pipeline and confirmed that a `nupkg` comes out that seems to have the expected contents.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* [ ] Documentation updated. Please add or update any docs in the repo as necessary.