### PR TITLE
SKUCrawler thread safety fixes and updating package dependencies.

### DIFF
--- a/src/BinaryBytes/BinaryBytes.csproj
+++ b/src/BinaryBytes/BinaryBytes.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Debugging.DataModel.DbgModelApiXtn" Version="20220617.1556.0" />
     <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220619.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -33,16 +33,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup Condition="'$(SizeBenchTestCode)'=='true' And '$(MSBuildProjectExtension)'=='.csproj'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <!--
-      Explicitly depending on a newer version of Newtonsoft.Json, since Microsoft.NET.Test.Sdk depends on Microsoft.TestPlatform.TestHost
-      that in turn depends on a vulnerable Newtonsoft.Json version.
-      It's possible this could be removed when moving to a newer Microsoft.NET.Test.Sdk, leaving the implicit dependency.
-    -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(SizeBenchTestCode)'=='true'">
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting"/>

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffRegressionTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffRegressionTests.cs
@@ -13,7 +13,7 @@ public sealed class DiffRegressionTests
 {
     public TestContext? TestContext { get; set; }
 
-    public string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    public string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     [TestMethod]
     public async Task SymbolDiffsForArraysWorkWhenArrayElementCountChanges()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateCompilandsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateCompilandsTests.cs
@@ -12,13 +12,13 @@ public sealed class DiffSession_EnumerateCompilandsTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateDuplicateDataItemDiffsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateDuplicateDataItemDiffsTests.cs
@@ -12,13 +12,13 @@ public sealed class DiffSession_EnumerateDuplicateDataItemDiffsTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateLibsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateLibsTests.cs
@@ -12,13 +12,13 @@ public sealed class DiffSession_EnumerateLibsTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSectionsAndCOFFGroupsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSectionsAndCOFFGroupsTests.cs
@@ -12,13 +12,13 @@ public sealed class DiffSession_EnumerateSectionsAndCOFFGroupsTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInBinarySectionTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInBinarySectionTests.cs
@@ -21,7 +21,7 @@ public sealed class DiffSession_EnumerateSymbolsInBinarySectionTests
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
 
-    public string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    public string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BeforeBinaryPath => MakePath("CppTestCases_BasicDiffObjectsBefore.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInCOFFGroupTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInCOFFGroupTests.cs
@@ -20,7 +20,7 @@ public sealed class DiffSession_EnumerateSymbolsInCOFFGroupTests
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
 
-    public string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    public string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BeforeBinaryPath => MakePath("CppTestCases_BasicDiffObjectsBefore.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInCompilandTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInCompilandTests.cs
@@ -14,13 +14,13 @@ public sealed class DiffSession_EnumerateSymbolsInCompilandTests
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInContributionTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInContributionTests.cs
@@ -14,13 +14,13 @@ public sealed class DiffSession_EnumerateSymbolsInContributionTests
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInLibTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateSymbolsInLibTests.cs
@@ -14,13 +14,13 @@ public sealed class DiffSession_EnumerateSymbolsInLibTests
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateWastefulVirtualItemDiffsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_EnumerateWastefulVirtualItemDiffsTests.cs
@@ -12,13 +12,13 @@ public sealed class DiffSession_EnumerateWastefulVirtualItemDiffsTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_LoadBinarySectionByNameTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_LoadBinarySectionByNameTests.cs
@@ -12,13 +12,13 @@ public sealed class DiffSession_LoadBinarySectionByNameTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.pdb");
 
     [TestMethod]
     public async Task LoadBinarySectionByNameUsesCacheIfPopulated()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_LoadSymbolDiffByBeforeAndAfterRVATests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_LoadSymbolDiffByBeforeAndAfterRVATests.cs
@@ -17,13 +17,13 @@ public sealed class DiffSession_LoadSymbolDiffByBeforeAndAfterRVATests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "CppTestCases_BasicDiffObjectsAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "CppTestCases_BasicDiffObjectsAfter.pdb");
 
     [TestMethod]
     public async Task SymbolDiffsCanBeLoadedByRVAs()
@@ -60,10 +60,10 @@ public sealed class DiffSession_LoadSymbolDiffByBeforeAndAfterRVATests
     public async Task SymbolDiffsCanBeLoadedByRVAsInRSRC()
     {
         using var logger = new NoOpLogger();
-        await using var diffSession = await DiffSession.Create(Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll"),
-                                                               Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb"),
-                                                               Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.dll"),
-                                                               Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.pdb"),
+        await using var diffSession = await DiffSession.Create(Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll"),
+                                                               Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb"),
+                                                               Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.dll"),
+                                                               Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.pdb"),
                                                                logger);
 
         var cursorDiff = await diffSession.LoadSymbolDiffByBeforeAndAfterRVA(0xB310, 0x7240, CancellationToken.None);

--- a/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_LoadTypeLayoutDiffsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Diffs/DiffSession_LoadTypeLayoutDiffsTests.cs
@@ -12,13 +12,13 @@ public sealed class DiffSession_LoadTypeLayoutDiffsTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
+    private string BeforeBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
 
-    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
+    private string BeforePDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
 
-    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.dll");
+    private string AfterBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.dll");
 
-    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.pdb");
+    private string AfterPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesAfter.pdb");
 
     [TestMethod]
     public async Task DiffWithSelfHasZeroSizeDiff()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Cpp17Tests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Cpp17Tests.cs
@@ -12,8 +12,8 @@ public class Cpp17Tests
 {
     public TestContext? TestContext { get; set; }
 
-    public string Cpp17BinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.Cpp17.dll");
-    public string Cpp17PdbPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.Cpp17.pdb");
+    public string Cpp17BinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.Cpp17.dll");
+    public string Cpp17PdbPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.Cpp17.pdb");
 
     [TestMethod]
     public async Task Cpp17XDATACanBeParsed()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/CustomAlignTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/CustomAlignTests.cs
@@ -10,7 +10,7 @@ public class CustomAlignTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.Dllx64CustomAlign.dll");
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.Dllx64CustomAlign.pdb");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DisassembleFunctionTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DisassembleFunctionTests.cs
@@ -17,7 +17,7 @@ public sealed class DisassembleFunctionTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DllArmTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DllArmTests.cs
@@ -22,8 +22,8 @@ public sealed class DllArmTests
         ArgumentNullException.ThrowIfNull(testContext);
 
         SessionLogger = new NoOpLogger();
-        DllArm32Session = await Session.Create(Path.Combine(testContext.DeploymentDirectory, "PEParser.Tests.Dllarm32.dll"),
-                                               Path.Combine(testContext.DeploymentDirectory, "PEParser.Tests.Dllarm32.pdb"),
+        DllArm32Session = await Session.Create(Path.Combine(testContext.DeploymentDirectory!, "PEParser.Tests.Dllarm32.dll"),
+                                               Path.Combine(testContext.DeploymentDirectory!, "PEParser.Tests.Dllarm32.pdb"),
                                                SessionLogger);
     }
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DllCxxFrameHandler4Tests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DllCxxFrameHandler4Tests.cs
@@ -10,7 +10,7 @@ namespace SizeBench.AnalysisEngine.RealPETests.Single_Binary;
 public class DllCxxFrameHandler4Tests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("PEParser.Tests.DllCxxFrameHandler4.dll");
     private string PDBPath => MakePath("PEParser.Tests.DllCxxFrameHandler4.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Dllx64Tests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Dllx64Tests.cs
@@ -11,7 +11,7 @@ namespace PEParser.Tests;
 public class Dllx64Tests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("PEParser.Tests.Dllx64.dll");
     private string PDBPath => MakePath("PEParser.Tests.Dllx64.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Dllx86Tests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Dllx86Tests.cs
@@ -11,7 +11,7 @@ public class Dllx86Tests
 {
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("PEParser.Tests.Dllx86.dll");
     private string PDBPath => MakePath("PEParser.Tests.Dllx86.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/ForceIntegrityBitTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/ForceIntegrityBitTests.cs
@@ -9,7 +9,7 @@ namespace SizeBench.AnalysisEngine.RealPETests.Single_Binary;
 public class ForceIntegrityBitTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.ForceIntegrityBit.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/FortranDllTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/FortranDllTests.cs
@@ -10,7 +10,7 @@ namespace SizeBench.AnalysisEngine.RealPETests.Single_Binary;
 public class FortranDllTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("FortranDll.dll");
     private string PDBPath => MakePath("FortranDll.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/MASMTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/MASMTests.cs
@@ -16,7 +16,7 @@ public sealed class MASMTests
 
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
 
-    public string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    public string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     [TestMethod]
     public async Task MASMProcPointersCanBeParsedAndAreNotInRVARangesWhenOverlappingOtherSymbols()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/ManagedBinaryTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/ManagedBinaryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Reflection;
 using SizeBench.Logging;
 
 namespace SizeBench.AnalysisEngine.RealPETests;
@@ -7,11 +8,11 @@ namespace SizeBench.AnalysisEngine.RealPETests;
 public sealed class ManagedBinaryTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private static string MakePath(string filename) => Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, filename);
 
-    private string BinaryPath => MakePath("SizeBench.AnalysisEngine.RealPETests.dll");
+    private static string BinaryPath => MakePath("SizeBench.AnalysisEngine.RealPETests.dll");
 
-    private string PDBPath => MakePath("SizeBench.AnalysisEngine.RealPETests.pdb");
+    private static string PDBPath => MakePath("SizeBench.AnalysisEngine.RealPETests.pdb");
 
     [ExpectedException(typeof(BinaryNotAnalyzableException), AllowDerivedTypes = false)]
     [TestMethod]
@@ -19,7 +20,7 @@ public sealed class ManagedBinaryTests
     {
         // SizeBench hasn't been taught how to inspect managed binaries yet, so we should throw to make our limitations clear.
         using var logger = new NoOpLogger();
-        await using var session = await Session.Create(this.BinaryPath, this.PDBPath, logger);
+        await using var session = await Session.Create(BinaryPath, PDBPath, logger);
         // We shouldn't get this far, as opening the session should throw
         Assert.Fail();
     }

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/MiniPDBTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/MiniPDBTests.cs
@@ -9,7 +9,7 @@ namespace SizeBench.AnalysisEngine.RealPETests;
 public class MiniPDBTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.Dllx64MinimalPDB.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/MismatchedBinaryAndPDBTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/MismatchedBinaryAndPDBTests.cs
@@ -9,7 +9,7 @@ namespace SizeBench.AnalysisEngine.RealPETests;
 public class MismatchedBinaryAndPDBTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/PGOTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/PGOTests.cs
@@ -23,8 +23,8 @@ public sealed class PGOTests
         ArgumentNullException.ThrowIfNull(testContext);
 
         SessionLogger = new NoOpLogger();
-        MUXSession = await Session.Create(Path.Combine(testContext.DeploymentDirectory, "Microsoft.UI.Xaml.dll"),
-                                          Path.Combine(testContext.DeploymentDirectory, "Microsoft.UI.Xaml.pdb"),
+        MUXSession = await Session.Create(Path.Combine(testContext.DeploymentDirectory!, "Microsoft.UI.Xaml.dll"),
+                                          Path.Combine(testContext.DeploymentDirectory!, "Microsoft.UI.Xaml.pdb"),
                                           SessionLogger);
     }
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/RustEnumTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/RustEnumTests.cs
@@ -10,7 +10,7 @@ namespace SizeBench.AnalysisEngine.RealPETests.Single_Binary;
 public class RustEnumTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("SizeBenchV2_AnalysisEngine_Tests_Rust.dll");
     private string PDBPath => MakePath("SizeBenchV2_AnalysisEngine_Tests_Rust.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/SessionTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/SessionTests.cs
@@ -12,13 +12,13 @@ public class SessionTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string CppDllBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppDll.dll");
+    private string CppDllBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppDll.dll");
 
-    private string CppDllPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppDll.pdb");
+    private string CppDllPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppDll.pdb");
 
-    private string Cpp32BitDllBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.Cpp32BitDll.dll");
+    private string Cpp32BitDllBinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.Cpp32BitDll.dll");
 
-    private string Cpp32BitDllPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.Cpp32BitDll.pdb");
+    private string Cpp32BitDllPDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.Cpp32BitDll.pdb");
 
     [TestMethod]
     public async Task BytesPerWordIsCorrectFor64Bit()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_BinarySectionsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_BinarySectionsTests.cs
@@ -11,7 +11,7 @@ namespace SizeBench.AnalysisEngine.Tests;
 public sealed class Session_BinarySectionsTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string CppDllBinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppDll.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateAnnotationsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateAnnotationsTests.cs
@@ -10,7 +10,7 @@ public sealed class Session_EnumerateAnnotationsTests
 {
     public TestContext? TestContext { get; set; }
 
-    public string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    public string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateDuplicateDataItemsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateDuplicateDataItemsTests.cs
@@ -14,7 +14,7 @@ public sealed class Session_EnumerateDuplicateDataItemsTests
 
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
 
-    public string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    public string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     [TestMethod]
     public async Task CppTestCasesBeforeDuplicateDataCanBeEnumerated()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateLibsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateLibsTests.cs
@@ -13,7 +13,7 @@ public sealed class Session_EnumerateLibsTests
 {
     public TestContext? TestContext { get; set; }
     public CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string CppDllBinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppDll.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSourceFilesTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSourceFilesTests.cs
@@ -10,9 +10,9 @@ public sealed class Session_EnumerateSourceFilesTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
+    private string BinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
 
-    private string PDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
+    private string PDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
 
     [TestMethod]
     public async Task SourceFilesCanBeEnumeratedWithPDataAndXDataAttributedToCorrectSourceFile()

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSymbolsInCOFFGroupTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSymbolsInCOFFGroupTests.cs
@@ -9,7 +9,7 @@ namespace SizeBench.AnalysisEngine.Tests;
 public sealed class Session_EnumerateSymbolsInCOFFGroupTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppDll.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSymbolsInCompilandTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSymbolsInCompilandTests.cs
@@ -11,7 +11,7 @@ public sealed class Session_EnumerateSymbolsInCompilandTests
 {
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSymbolsInLibTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSymbolsInLibTests.cs
@@ -9,7 +9,7 @@ namespace SizeBench.AnalysisEngine.Tests;
 public sealed class Session_EnumerateSymbolsInLibTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppDll.dll");
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSymbolsInSourceFileTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateSymbolsInSourceFileTests.cs
@@ -11,9 +11,9 @@ public sealed class Session_EnumerateSymbolsInSourceFileTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string BinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
+    private string BinaryPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
 
-    private string PDBPath => Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
+    private string PDBPath => Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");
 
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateTemplateFoldabilityTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateTemplateFoldabilityTests.cs
@@ -11,7 +11,7 @@ public sealed class Session_EnumerateTemplateFoldabilityTests
 {
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
-    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateWastefulVirtualsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_EnumerateWastefulVirtualsTests.cs
@@ -12,7 +12,7 @@ public sealed class Session_EnumerateWastefulVirtualsTests
 {
     public TestContext? TestContext { get; set; }
 
-    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_LoadTypeLayoutTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_LoadTypeLayoutTests.cs
@@ -10,7 +10,7 @@ namespace SizeBench.AnalysisEngine.RealPETests;
 public sealed class Session_LoadTypeLayoutTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_RVADuplicationTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Session_RVADuplicationTests.cs
@@ -23,8 +23,8 @@ public sealed class Session_RVADuplicationTests
         ArgumentNullException.ThrowIfNull(testContext);
 
         SessionLogger = new NoOpLogger();
-        ReactNativeXamlSession = await Session.Create(Path.Combine(testContext.DeploymentDirectory, "ReactNativeXaml.dll"),
-                                                      Path.Combine(testContext.DeploymentDirectory, "ReactNativeXaml.pdb"),
+        ReactNativeXamlSession = await Session.Create(Path.Combine(testContext.DeploymentDirectory!, "ReactNativeXaml.dll"),
+                                                      Path.Combine(testContext.DeploymentDirectory!, "ReactNativeXaml.pdb"),
                                                       SessionLogger);
     }
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/UDT_LoadFunctionsTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/UDT_LoadFunctionsTests.cs
@@ -11,7 +11,7 @@ public sealed class UDT_LoadFunctionsTests
 {
     public TestContext? TestContext { get; set; }
     private CancellationToken CancellationToken => this.TestContext!.CancellationTokenSource.Token;
-    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory, binary);
+    private string MakePath(string binary) => Path.Combine(this.TestContext!.DeploymentDirectory!, binary);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");

--- a/src/SizeBench.AnalysisEngine.RealPETests/SizeBench.AnalysisEngine.RealPETests.csproj
+++ b/src/SizeBench.AnalysisEngine.RealPETests/SizeBench.AnalysisEngine.RealPETests.csproj
@@ -21,12 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Castle.Windsor" Version="5.1.2" />
-        <!--
-          Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-          It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-        -->
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Castle.Windsor" Version="6.0.0" />
         <PackageReference Include="Microsoft.Debugging.DataModel.DbgModelApiXtn" Version="20220617.1556.0" />
         <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220619.1.0" />
         <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />

--- a/src/SizeBench.AnalysisEngine.Tests/SizeBench.AnalysisEngine.Tests.csproj
+++ b/src/SizeBench.AnalysisEngine.Tests/SizeBench.AnalysisEngine.Tests.csproj
@@ -5,12 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Castle.Windsor" Version="5.1.2" />
-        <!--
-          Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-          It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-        -->
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Castle.Windsor" Version="6.0.0" />
         <PackageReference Include="Microsoft.Debugging.DataModel.DbgModelApiXtn" Version="20220617.1556.0" />
         <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220619.1.0" />
     </ItemGroup>

--- a/src/SizeBench.AnalysisEngine/SizeBench.AnalysisEngine.csproj
+++ b/src/SizeBench.AnalysisEngine/SizeBench.AnalysisEngine.csproj
@@ -6,12 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Windsor" Version="5.1.2" />
-    <!--
-      Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-      It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-    -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Castle.Windsor" Version="6.0.0" />
     <PackageReference Include="Microsoft.Debugging.DataModel.DbgModelApiXtn" Version="20220617.1556.0" />
     <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220619.1.0" />
   </ItemGroup>

--- a/src/SizeBench.ExcelExporter/SizeBench.ExcelExporter.csproj
+++ b/src/SizeBench.ExcelExporter/SizeBench.ExcelExporter.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Castle.Windsor" Version="5.1.2" />
-    <!--
-      Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-      It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-    -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Castle.Windsor" Version="6.0.0" />
     <PackageReference Include="ClosedXML" Version="0.96.0" />
   </ItemGroup>
 

--- a/src/SizeBench.GUI.RealPETests/Controls/TypeLayoutTreeView/TypeLayoutDataTemplateSelectorTests.cs
+++ b/src/SizeBench.GUI.RealPETests/Controls/TypeLayoutTreeView/TypeLayoutDataTemplateSelectorTests.cs
@@ -40,7 +40,7 @@ public class TypeLayoutDataTemplateSelectorTests
     }
 
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BeforeBinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
     private string BeforePDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");

--- a/src/SizeBench.GUI.RealPETests/Controls/TypeLayoutTreeView/TypeLayoutItemDiffViewModelTests.cs
+++ b/src/SizeBench.GUI.RealPETests/Controls/TypeLayoutTreeView/TypeLayoutItemDiffViewModelTests.cs
@@ -13,7 +13,7 @@ namespace SizeBench.GUI.Controls.TypeLayoutTreeView.Tests;
 public class TypeLayoutItemDiffViewModelTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BeforeBinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
     private string BeforePDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");

--- a/src/SizeBench.GUI.RealPETests/Controls/TypeLayoutTreeView/TypeLayoutItemViewModelTests.cs
+++ b/src/SizeBench.GUI.RealPETests/Controls/TypeLayoutTreeView/TypeLayoutItemViewModelTests.cs
@@ -11,7 +11,7 @@ namespace SizeBench.GUI.Controls.TypeLayoutTreeView.Tests;
 public class TypeLayoutItemViewModelTests
 {
     public TestContext? TestContext { get; set; }
-    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory, filename);
+    private string MakePath(string filename) => Path.Combine(this.TestContext!.DeploymentDirectory!, filename);
 
     private string BinaryPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll");
     private string PDBPath => MakePath("SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb");

--- a/src/SizeBench.GUI.RealPETests/SizeBench.GUI.RealPETests.csproj
+++ b/src/SizeBench.GUI.RealPETests/SizeBench.GUI.RealPETests.csproj
@@ -14,12 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Windsor" Version="5.1.2" />
-    <!--
-      Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-      It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-    -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Castle.Windsor" Version="6.0.0" />
     <PackageReference Include="Microsoft.Debugging.DataModel.DbgModelApiXtn" Version="20220617.1556.0" />
     <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220619.1.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />

--- a/src/SizeBench.GUI.RealPETests/UserDefinedTypeSymbol_STATests.cs
+++ b/src/SizeBench.GUI.RealPETests/UserDefinedTypeSymbol_STATests.cs
@@ -26,8 +26,8 @@ public sealed class UserDefinedTypeSymbol_STATests
     {
         AsyncContext.Run(async () =>
         {
-            await using var session = await Session.Create(Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll"),
-                                                           Path.Combine(this.TestContext!.DeploymentDirectory, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb"),
+            await using var session = await Session.Create(Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.dll"),
+                                                           Path.Combine(this.TestContext!.DeploymentDirectory!, "SizeBenchV2.AnalysisEngine.Tests.CppTestCasesBefore.pdb"),
                                                            new NoOpLogger());
 
             var sections = await session.EnumerateBinarySectionsAndCOFFGroups(this.CancellationToken);

--- a/src/SizeBench.GUI.Tests/SizeBench.GUI.Tests.csproj
+++ b/src/SizeBench.GUI.Tests/SizeBench.GUI.Tests.csproj
@@ -6,12 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Windsor" Version="5.1.2" />
-    <!--
-      Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-      It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-    -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Castle.Windsor" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SizeBench.GUI/SizeBench.GUI.csproj
+++ b/src/SizeBench.GUI/SizeBench.GUI.csproj
@@ -23,12 +23,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Castle.Windsor" Version="5.1.2" />
-    <!--
-      Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-      It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-    -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Castle.Windsor" Version="6.0.0" />
     <PackageReference Include="Microsoft.Debugging.DataModel.DbgModelApiXtn" Version="20220617.1556.0" />
     <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220619.1.0" />
     <PackageReference Include="DiffPlex.Wpf" Version="1.3.1" />

--- a/src/SizeBench.LocalBuild/SizeBench.LocalBuild.csproj
+++ b/src/SizeBench.LocalBuild/SizeBench.LocalBuild.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Windsor" Version="5.1.2" />
-        <!--
-          Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-          It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-        -->
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+		<PackageReference Include="Castle.Windsor" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SizeBench.SKUCrawler/SizeBench.SKUCrawler.csproj
+++ b/src/SizeBench.SKUCrawler/SizeBench.SKUCrawler.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Debugging.DataModel.DbgModelApiXtn" Version="20220617.1556.0" />
     <PackageReference Include="Microsoft.Debugging.Platform.DbgX" Version="20220619.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.9" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
   </ItemGroup>
 

--- a/src/SizeBench.TestDataCommon/SizeBench.TestDataCommon.csproj
+++ b/src/SizeBench.TestDataCommon/SizeBench.TestDataCommon.csproj
@@ -6,12 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Castle.Windsor" Version="5.1.2" />
-        <!--
-          Explicitly depending on a newer version of Newtonsoft.Json, since Windsor depends on an old version that in turn depends on a vulnerable Newtonsoft.Json version.
-          It's possible this could be removed when moving to a newer Castle.Windsor, leaving the implicit dependency.
-        -->
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+        <PackageReference Include="Castle.Windsor" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Why is this change being made?
The SKUCrawler tool is used by the Windows Engineering System and runs at huge scale - recently we've seen issues with the controller process where it looks like a latent thread safety bug is causing the tool to fail.

## Briefly summarize what changed
This changes the controller process to use more thread-safe data structures.

I also updated the package dependencies for some core packages as we should no longer need to explicitly depend on Newtonsoft.Json 13.0.1, which brought in a nullability change in the MSTest DeploymentDirectory so now that needs to be suppressed in many places as we always use deployment and it'll never be null for SizeBench tests.

## How was the change tested?
Ran all the existing tests.  This shouldn't need new tests, as it's essentially a race condition and (a) race conditions are super hard to test for, and (b) SKUCrawler has no test suite currently.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* [x] Documentation updated. Please add or update any docs in the repo as necessary.