### PR TITLE
Get to a clean build with latest VS 2022 and .NET 8 SDKs

### DIFF
--- a/src/SizeBench.AnalysisEngine/DIAInterop/DIAAdapter.cs
+++ b/src/SizeBench.AnalysisEngine/DIAInterop/DIAAdapter.cs
@@ -1442,14 +1442,14 @@ internal sealed class DIAAdapter : IDIAAdapter, IDisposable
         }
     }
 
-    private void RecursivelyFindSymbols(IDiaSymbol parentSymbol,
-                                        SymTagEnum[] symTagsToSearchThrough,
-                                        SymTagEnum symTagToProcess,
-                                        CancellationToken cancellationToken,
-                                        Action<IDiaSymbol> processSymbol,
-                                        string? nameFilter = null,
-                                        bool filterWithUndecoratedNames = false,
-                                        uint currentDepthOfRecursion = 0)
+    private static void RecursivelyFindSymbols(IDiaSymbol parentSymbol,
+                                               SymTagEnum[] symTagsToSearchThrough,
+                                               SymTagEnum symTagToProcess,
+                                               CancellationToken cancellationToken,
+                                               Action<IDiaSymbol> processSymbol,
+                                               string? nameFilter = null,
+                                               bool filterWithUndecoratedNames = false,
+                                               uint currentDepthOfRecursion = 0)
     {
         // The reason we pass around 'symTagsToSearchThrough' is that iterating through every symbol in a large binary can be extraordinarily slow and 
         // allocates a ton of very short-lived COM objects, when callers will know what sym tags can ever contain the things they're searching for.

--- a/src/SizeBench.AnalysisEngine/Session.cs
+++ b/src/SizeBench.AnalysisEngine/Session.cs
@@ -642,7 +642,7 @@ public sealed class Session : ISession
         // be properly coded and tested if it's important.
         if (member.Offset != Convert.ToUInt32(member.Offset))
         {
-            throw new ArgumentOutOfRangeException(nameof(member), "member.Offset is not able to be represented as a uint - this is unexpected.  How did this happen?");
+            throw new ArgumentOutOfRangeException(nameof(member), "offset of member is not able to be represented as a uint - this is unexpected.  How did this happen?");
         }
 
         // When loading the layout of a member, if it's a pointer or an array, we'll "chase through" to find the UDT but we don't

--- a/src/SizeBench.AnalysisEngine/SessionTasks/EnumerateWastefulVirtualsSessionTask.cs
+++ b/src/SizeBench.AnalysisEngine/SessionTasks/EnumerateWastefulVirtualsSessionTask.cs
@@ -254,7 +254,7 @@ internal sealed class EnumerateWastefulVirtualsSessionTask : SessionTask<List<Wa
     private static bool IsPureVirtualFunction(IFunctionCodeSymbol function)
         => function.IsPure && IsVirtualFunction(function);
 
-    private bool BaseTypeContainsVirtualFunction(UserDefinedTypeSymbol thisClass, string functionFormattedName)
+    private static bool BaseTypeContainsVirtualFunction(UserDefinedTypeSymbol thisClass, string functionFormattedName)
     {
         if (thisClass.Functions != null &&
             thisClass.Functions.Any(f => IsVirtualFunction(f) &&

--- a/src/SizeBench.AnalysisEngine/SessionTasks/LoadTypeLayoutSessionTask.cs
+++ b/src/SizeBench.AnalysisEngine/SessionTasks/LoadTypeLayoutSessionTask.cs
@@ -48,7 +48,7 @@ internal class LoadTypeLayoutSessionTask : SessionTask<List<TypeLayoutItem>>
         }
     }
 
-    private UserDefinedTypeSymbol? ChaseThroughToUDT(TypeSymbol typeSymbol)
+    private static UserDefinedTypeSymbol? ChaseThroughToUDT(TypeSymbol typeSymbol)
     {
         if (typeSymbol is PointerTypeSymbol ptrType)
         {
@@ -327,7 +327,7 @@ internal class LoadTypeLayoutSessionTask : SessionTask<List<TypeLayoutItem>>
         return null;
     }
 
-    private decimal MaxOffsetPlusSizeSeenByAnyBaseType(IEnumerable<TypeLayoutItem>? baseTypeLayouts)
+    private static decimal MaxOffsetPlusSizeSeenByAnyBaseType(IEnumerable<TypeLayoutItem>? baseTypeLayouts)
     {
         if (baseTypeLayouts is null)
         {
@@ -393,7 +393,7 @@ internal class LoadTypeLayoutSessionTask : SessionTask<List<TypeLayoutItem>>
         return baseTypeLayouts;
     }
 
-    private TypeLayoutItemMember? GetLastMemberOffsetFromBaseTypeLayouts(TypeLayoutItem[]? baseTypeLayouts)
+    private static TypeLayoutItemMember? GetLastMemberOffsetFromBaseTypeLayouts(TypeLayoutItem[]? baseTypeLayouts)
     {
         if (baseTypeLayouts is null)
         {
@@ -421,7 +421,7 @@ internal class LoadTypeLayoutSessionTask : SessionTask<List<TypeLayoutItem>>
         return lastFromAnyBaseType;
     }
 
-    private TypeLayoutItemMember? GetLastMemberByOffsetFromItem(TypeLayoutItem type)
+    private static TypeLayoutItemMember? GetLastMemberByOffsetFromItem(TypeLayoutItem type)
     {
         TypeLayoutItemMember? lastFromAnyBaseType = null;
 
@@ -478,7 +478,7 @@ internal class LoadTypeLayoutSessionTask : SessionTask<List<TypeLayoutItem>>
         }
     }
 
-    private bool BaseTypeLayoutsContainVfptrAtOffsetAlready(UserDefinedTypeSymbol udt, IEnumerable<TypeLayoutItem>? baseTypeLayouts, uint offset)
+    private static bool BaseTypeLayoutsContainVfptrAtOffsetAlready(UserDefinedTypeSymbol udt, IEnumerable<TypeLayoutItem>? baseTypeLayouts, uint offset)
     {
         if (udt.VTableCount == 0 || baseTypeLayouts is null)
         {
@@ -496,7 +496,7 @@ internal class LoadTypeLayoutSessionTask : SessionTask<List<TypeLayoutItem>>
         return false;
     }
 
-    private bool ItemContainsVfptrAtOffsetAlready(TypeLayoutItem item, uint offset)
+    private static bool ItemContainsVfptrAtOffsetAlready(TypeLayoutItem item, uint offset)
     {
         if (item.UserDefinedType.VTableCount == 0)
         {

--- a/src/SizeBench.GUI/GlobalSuppressions.cs
+++ b/src/SizeBench.GUI/GlobalSuppressions.cs
@@ -25,3 +25,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression",
                            Justification = "The suppressions that can be removed get too noisy with VS and SDK updates changing the rules over time, and they're harmless to leave in.  Ignoring this to avoid noise in the VS Error List window.",
                            Scope = "namespaceanddescendants", Target = "~N:SizeBench.GUI")]
+
+[assembly: SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", 
+                           Justification = "Argument exceptions ordering isn't that important in the GUI, it's not a library used externally.  Also, there have been some regressions in CA2208 in the .NET 8 SDK where it has false positives (see https://github.com/dotnet/roslyn-analyzers/issues/6863)",
+                           Scope = "namespaceanddescendants", Target = "~N:SizeBench.GUI")]

--- a/src/SizeBench.GUI/MainWindowViewModel.cs
+++ b/src/SizeBench.GUI/MainWindowViewModel.cs
@@ -445,7 +445,7 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged, IDialogServi
         return diffSession;
     }
 
-    private Exception? ExtractExceptionNotWorthErrorReportingIfPossible(Exception ex)
+    private static Exception? ExtractExceptionNotWorthErrorReportingIfPossible(Exception ex)
     {
         if (ex is AggregateException aggregateException)
         {
@@ -472,7 +472,7 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged, IDialogServi
         return null;
     }
 
-    private Exception UnwrapDegenerateAggregateExceptions(Exception ex)
+    private static Exception UnwrapDegenerateAggregateExceptions(Exception ex)
     {
         if (ex is AggregateException aggregateException &&
             aggregateException.InnerExceptions.Count == 1)

--- a/src/SizeBench.TestDataCommon/DiffTestDataGenerator.cs
+++ b/src/SizeBench.TestDataCommon/DiffTestDataGenerator.cs
@@ -1738,7 +1738,7 @@ internal sealed class DiffTestDataGenerator : IDisposable
         return complexFn;
     }
 
-    private bool IsCOMType(UserDefinedTypeSymbol udt)
+    private static bool IsCOMType(UserDefinedTypeSymbol udt)
     {
         if (udt.Name == "IUnknown")
         {


### PR DESCRIPTION
## Why is this change being made?
With the latest Visual Studio 2022 and .NET 8 SDKs, some Roslyn rules went from nothing to suggestion, and because SizeBench cranks most things up to error, this causes build errors.  So this gets us back to a clean build on the latest SDK.

## Briefly summarize what changed
There's two fixes:

1. If it's a trivial fix, just fix it (e.g. functions that should be static because they don't touch instance data)
2. CA2208 has a regression in the .NET 8 SDK with false positives (see https://github.com/dotnet/roslyn-analyzers/issues/6863), so disable that one in the GUI project.  It's low value there anyway.

## How was the change tested?
The build is the main test, but of course all existing tests also pass.

## PR Checklist

 * [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
 * [x] Changes have been validated
 * [x] Documentation updated. Please add or update any docs in the repo as necessary.