### PR TITLE
Fix some issues with PDATA, fix binary locator, and address a couple warnings

### DIFF
--- a/src/RunSettings.runsettings
+++ b/src/RunSettings.runsettings
@@ -62,6 +62,9 @@
                 <ModulePath>.*SizeBench.*TestDataCommon\.dll$</ModulePath>
                 <ModulePath>.*moq\.dll$</ModulePath>
                 <ModulePath>.*SizeBench.*TestData.*</ModulePath>
+                <!-- Exclude Test PEs so we don't instrument the checked-in test collateral, which can subtly change it -->
+                <ModulePath>.*Test PEs.*</ModulePath>
+                <ModulePath>.*TestPEs.*</ModulePath>
               </Exclude>
             </ModulePaths>
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DllArmTests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DllArmTests.cs
@@ -42,15 +42,9 @@ public sealed class DllArmTests
     {
         Assert.IsNotNull(DllArm32Session);
 
-        // These are gotten from "link /dump /headers PEParser.Tests.Dllarm32.dll" and looking at the .pdata section-
-        // "virtual address" and "virtual size"
+        // These are gotten from "link /dump /headers PEParser.Tests.Dllarm32.dll" and looking at the "Exception" directory
         Assert.AreEqual(0x7000u, DllArm32Session.DataCache.PDataRVARange!.RVAStart);
-
-        // Note that the size will be rounded up to the nearest section alignment, so it will be 0x1000
-        // because the next section (.gfids) doesn't begin until 0x8000
-        // To make this test easier to update as the binary may change, we calculate this as
-        // (beginning of .gfids - beginning of .pdata)
-        Assert.AreEqual(0x8000u - 0x7000u, DllArm32Session.DataCache.PDataRVARange!.Size);
+        Assert.AreEqual(0x318u, DllArm32Session.DataCache.PDataRVARange!.Size);
 
         // We should be discovering a bunch of RVA Ranges that we then coalesce down to just two: cppxdata in .rdata and the .xdata COFF Group
         Assert.AreEqual(2, DllArm32Session.DataCache.XDataRVARanges!.Count);

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DllCxxFrameHandler4Tests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/DllCxxFrameHandler4Tests.cs
@@ -20,15 +20,9 @@ public class DllCxxFrameHandler4Tests
     {
         using var logger = new NoOpLogger();
         await using var session = await Session.Create(this.BinaryPath, this.PDBPath, logger);
-        // These are gotten from "link /dump /headers PEParser.Tests.DllCxxFrameHandler4.dll" and looking at the .pdata section-
-        // "virtual address" and "virtual size"
+        // These are gotten from "link /dump /headers PEParser.Tests.DllCxxFrameHandler4.dll" and looking at the "Exception" directory
         Assert.AreEqual(0x5000u, session.DataCache.PDataRVARange!.RVAStart);
-
-        // Note that the size will be rounded up to the nearest section alignment, so it will be 0x1000
-        // because the next section (.rsrc) doesn't begin until 0x6000
-        // To make this test easier to update as the binary may change, we calculate this as
-        // (beginning of .rsrc - beginning of .pdata)
-        Assert.AreEqual(0x6000u - 0x5000u, session.DataCache.PDataRVARange.Size);
+        Assert.AreEqual(0x2E8u, session.DataCache.PDataRVARange.Size);
 
         Assert.AreEqual(1, session.DataCache.XDataRVARanges!.Count);
 

--- a/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Dllx64Tests.cs
+++ b/src/SizeBench.AnalysisEngine.RealPETests/Single Binary/Dllx64Tests.cs
@@ -36,15 +36,9 @@ public class Dllx64Tests
     {
         using var logger = new NoOpLogger();
         await using var session = await Session.Create(this.BinaryPath, this.PDBPath, logger);
-        // These are gotten from "link /dump /headers PEParser.Tests.Dllx64.dll" and looking at the .pdata section-
-        // "virtual address" and "virtual size"
+        // These are gotten from "link /dump /headers PEParser.Tests.Dllx64.dll" and looking at the "Exception" directory
         Assert.AreEqual(0x7000u, session.DataCache.PDataRVARange!.RVAStart);
-
-        // Note that the size will be rounded up to the nearest section alignment, so it will be 0x1000
-        // because the next section (.gfids) doesn't begin until 0x8000
-        // To make this test easier to update as the binary may change, we calculate this as
-        // (beginning of .gfids - beginning of .pdata)
-        Assert.AreEqual(0x8000u - 0x7000u, session.DataCache.PDataRVARange.Size);
+        Assert.AreEqual(0x3C0u, session.DataCache.PDataRVARange.Size);
 
         // We should be discovering two RVA Ranges for xdata symbols for this binary.
         Assert.AreEqual(2, session.DataCache.XDataRVARanges!.Count);

--- a/src/SizeBench.AnalysisEngine/PE/ARM_EHParser.cs
+++ b/src/SizeBench.AnalysisEngine/PE/ARM_EHParser.cs
@@ -36,7 +36,7 @@ internal sealed unsafe class ARM_EHParser : EHSymbolParser
 
     public ARM_EHParser(IDIAAdapter diaAdapter,
                         byte* libraryBaseAddress,
-                        MachineType machineType) : base(diaAdapter, libraryBaseAddress, machineType)
+                        PEFile peFile) : base(diaAdapter, libraryBaseAddress, peFile)
     {
         this.__GSHandlerCheck_EHRva = diaAdapter.SymbolRvaFromName("__GSHandlerCheck_EH", true);
         this.__GSHandlerCheck_EH4Rva = diaAdapter.SymbolRvaFromName("__GSHandlerCheck_EH4", true);
@@ -49,9 +49,9 @@ internal sealed unsafe class ARM_EHParser : EHSymbolParser
         this.__GSHandlerCheckRva = diaAdapter.SymbolRvaFromName("__GSHandlerCheck", true);
     }
 
-    protected override SortedList<uint, PDataSymbol> ParsePDataForArchitecture(uint sectionAlignment, SessionDataCache cache)
+    protected override SortedList<uint, PDataSymbol> ParsePDataForArchitecture(SessionDataCache cache)
     {
-        var pdataFunctions = ParsePDATA<ARM_RUNTIME_FUNCTION>(this.LibraryBaseAddress, sectionAlignment, cache);
+        var pdataFunctions = ParsePDATA<ARM_RUNTIME_FUNCTION>(this.LibraryBaseAddress, cache);
 
         // There's no pdata, so we're done
         if (pdataFunctions is null)
@@ -102,7 +102,7 @@ internal sealed unsafe class ARM_EHParser : EHSymbolParser
         return pdataSymbols;
     }
 
-    protected override void ParseXDataForArchitecture(uint sectionAlignment, RVARange? XDataRVARange, SessionDataCache cache)
+    protected override void ParseXDataForArchitecture(RVARange? XDataRVARange, SessionDataCache cache)
     {
         foreach (var pds in cache.PDataSymbolsByRVA!.Values)
         {

--- a/src/SizeBench.AnalysisEngine/PE/EHSymbolTable.cs
+++ b/src/SizeBench.AnalysisEngine/PE/EHSymbolTable.cs
@@ -6,21 +6,21 @@ namespace SizeBench.AnalysisEngine.PE;
 
 internal static class EHSymbolTable
 {
-    internal static unsafe void Parse(byte* libraryBaseAddress, uint sectionAlignment, SessionDataCache dataCache, IDIAAdapter diaAdapter, MachineType machine, RVARange? XDataRVARange, ILogger logger)
+    internal static unsafe void Parse(byte* libraryBaseAddress, SessionDataCache dataCache, IDIAAdapter diaAdapter, PEFile peFile, RVARange? XDataRVARange, ILogger logger)
     {
         EHSymbolParser ehParser;
-        switch (machine)
+        switch (peFile.MachineType)
         {
             case MachineType.x64:
                 ehParser = new AMD64_EHParser(diaAdapter,
                                               libraryBaseAddress,
-                                              machine);
+                                              peFile);
                 break;
             case MachineType.ARM:
             case MachineType.ARM64:
                 ehParser = new ARM_EHParser(diaAdapter,
                                             libraryBaseAddress,
-                                            machine);
+                                            peFile);
                 break;
             case MachineType.I386:
                 // x86 Exception Handling (EH) does not have pdata and xdata structures the way they exist in other architectures
@@ -30,10 +30,10 @@ internal static class EHSymbolTable
                 dataCache.XDataSymbolsByRVA = new SortedList<uint, XDataSymbol>();
                 return;
             default:
-                throw new ArgumentException($"Unknown machine type to parse xdata for ({machine}).  This is a bug in SizeBench's implementation, not your use of it.", nameof(machine));
+                throw new ArgumentException($"Unknown machine type to parse xdata for ({peFile.MachineType}).  This is a bug in SizeBench's implementation, not your use of it.", nameof(peFile));
         }
 
-        ehParser.Parse(sectionAlignment, XDataRVARange, dataCache, logger);
+        ehParser.Parse(XDataRVARange, dataCache, logger);
     }
 
     internal static uint GetAdjustedRva(uint rva, MachineType machine)

--- a/src/SizeBench.AnalysisEngine/PE/PInvokes.cs
+++ b/src/SizeBench.AnalysisEngine/PE/PInvokes.cs
@@ -679,7 +679,7 @@ internal readonly struct IMAGE_SECTION_HEADER
         get
         {
             var nameString = new string(this.Name);
-            if (nameString.IndexOf('\0', StringComparison.Ordinal) != -1)
+            if (nameString.Contains('\0', StringComparison.Ordinal))
             {
                 nameString = nameString[..nameString.IndexOf('\0', StringComparison.Ordinal)];
             }

--- a/src/SizeBench.GUI/MainWindowViewModel.cs
+++ b/src/SizeBench.GUI/MainWindowViewModel.cs
@@ -292,7 +292,7 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged, IDialogServi
         var container = new WindsorContainer();
         var newTab = new SingleBinaryTab(session, container);
 
-        container.Install(FromAssembly.InDirectory(new AssemblyFilter(".", "SizeBench.*")));
+        container.Install(FromAssembly.InDirectory(new AssemblyFilter(".", "SizeBench.*dll")));
         container.Register(reg.Component.For<ISession, ISessionWithProgress>()
                                         .Instance(session)
                                         .LifestyleSingleton());

--- a/src/SizeBench.GUI/Program.cs
+++ b/src/SizeBench.GUI/Program.cs
@@ -32,7 +32,7 @@ public static class Program
                                                     GenericUriParserOptions.DontCompressPath), "sizebench", -1);
         }
 
-        _windsorContainer.Install(FromAssembly.InDirectory(new AssemblyFilter(".", "SizeBench.*")));
+        _windsorContainer.Install(FromAssembly.InDirectory(new AssemblyFilter(".", "SizeBench.*dll")));
         _logger = _windsorContainer.Resolve<IApplicationLogger>();
 
         using (var startupInfoLogs = _logger.StartTaskLog("Launch info"))

--- a/src/SizeBench.LocalBuild/WindsorInstaller.cs
+++ b/src/SizeBench.LocalBuild/WindsorInstaller.cs
@@ -1,0 +1,18 @@
+﻿using Castle.MicroKernel.Registration;
+using Castle.MicroKernel.SubSystems.Configuration;
+using Castle.Windsor;
+using SizeBench.PathLocators;
+
+namespace SizeBench.LocalBuild;
+
+public sealed class WindsorInstaller : IWindsorInstaller
+{
+    public void Install(IWindsorContainer container, IConfigurationStore store)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+
+        container.Register(Component.For<IBinaryLocator>()
+                                    .ImplementedBy<LocalBuildPathLocator>()
+                                    .LifestyleSingleton());
+    }
+}


### PR DESCRIPTION
## Why is this change being made?
A customer reported issues with some of their binaries thinking they had chained PDATA records (very uncommon for x64, so SizeBench doesn't support that yet).  As I investigated, it turned out that there were two problems:

1. Some `UNWIND_INFO` structures have a version 0 and flags 0, so they can be skipped.
2. The PDATA doesn't always live in its own section, nor is it required to take up a full section.  SizeBench was assuming that and that's wrong - instead we should look at the "Exception" directory of the PE optional header which has the exact location and length of the PDATA array.  Because SizeBench was reading this wrong in some edge cases, we'd get garbage/misaligned data in the PDATA and think we were trying to parse chained PDATA when in fact that wasn't the case.
 
## Briefly summarize what changed
* Fix PDATA RVA range to be correct, and correspondingly update the tests.
* If we find an `UNWIND_INFO` with version == 0 and flags == 0, just skip it.

While I was doing this, I also did a little cleanup:
* Fix the missing `IBinaryLocator` that used to be present, somehow this probably got lost in the merge to get this moved from an MS-internal repo to GitHub (Fixes #22).
* Fix a couple warnings that were lingering since the .NET 8 SDK updated, just for hygiene
* Fix an issue where the Test PEs were being instrumented by the code coverage instrumentation during code coverage runs, which isn't desirable as we want these PEs to be bit-for-bit exactly what was checked in, since we look at a lot of data structures and test specific values precisely.  This makes the tests way more reliable in Visual Studio (CI runs seemed unaffected this whole time)

## How was the change tested?
* All existing tests pass, and the PGOTests are much more reliable due to the code coverage fix included here.
* Tested the customer-provided binaries and both now parse correctly when they used to throw on load before.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* [ ] ~Documentation updated. Please add or update any docs in the repo as necessary.~