### PR TITLE
Fix about box being unable to open, and correct link to how to contribute

### DIFF
--- a/src/SizeBench.GUI/Windows/AboutBox.xaml
+++ b/src/SizeBench.GUI/Windows/AboutBox.xaml
@@ -68,12 +68,12 @@
                         </Hyperlink>
                     </Label>
                     <Label Style="{StaticResource LinkLabelStyle}">
-                        <Hyperlink NavigateUri="https://msblox.visualstudio.com/_git/SizeBench?path=%2FDocs%2FContributing.md"
+                        <Hyperlink NavigateUri="https://github.com/microsoft/SizeBench/blob/main/docs/Contributing.md"
                                    Style="{StaticResource LinkLabelStyle}">
                             <i:Interaction.Behaviors>
                                 <navigationControls:ExternalHyperlinkNavigationBehavior/>
                             </i:Interaction.Behaviors>
-                            <TextBlock Text="How to contribute (MS internal only for now)"/>
+                            <TextBlock Text="How to contribute"/>
                         </Hyperlink>
                     </Label>
                 </StackPanel>

--- a/src/SizeBench.GUI/Windows/WindowTitleBarExtensions.cs
+++ b/src/SizeBench.GUI/Windows/WindowTitleBarExtensions.cs
@@ -10,11 +10,11 @@ namespace SizeBench.GUI.Windows;
 internal static partial class WindowTitleBarExtensions
 {
     [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-    [LibraryImport("user32.dll")]
+    [LibraryImport("user32.dll", EntryPoint = "GetWindowLongW")]
     private static partial uint GetWindowLong(IntPtr hWnd, int nIndex);
 
     [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-    [LibraryImport("user32.dll")]
+    [LibraryImport("user32.dll", EntryPoint = "SetWindowLongW")]
     private static partial void SetWindowLong(IntPtr hWnd, int nIndex, uint dwNewLong);
 
     private const int GWL_STYLE = -16;


### PR DESCRIPTION
## Why is this change being made?
With the recent upgrade to .NET 8, `[DllImport]` was changed to `[LibraryImport]` as recommended by the Roslyn analyzers for performance.  But these APIs end in "W" like a lot of old Win32 APIs and the analyzer auto-fix didn't do that, so the P/Invokes failed to find the right exported function and thus the about box threw an exception and failed to open.

## Briefly summarize what changed
Fixed the P/Invokes to call into the right functions, and while I was here I noticed I forgot to update the "how to contribute" link when this repo became public, so might as well update that too.

## How was the change tested?
Locally ran and verified no exception thrown.  This is all UI code so I don't have unit testing in place (which is why this slipped through the cracks with the .NET 8 upgrade).

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* ~[ ] Documentation updated. Please add or update any docs in the repo as necessary.~