### PR TITLE
Add PGO dynamic instruction count, and add SQL views to BinaryBytes

### DIFF
--- a/src/BinaryBytes/BytesItem.cs
+++ b/src/BinaryBytes/BytesItem.cs
@@ -11,4 +11,5 @@ internal sealed class BytesItem
     public bool IsPadding { get; set; }
     public bool IsPGO { get; set; }
     public bool IsOptimizedForSpeed { get; set; }
+    public ulong DynamicInstructionCount { get; set; }
 }

--- a/src/BinaryBytes/Utilities.cs
+++ b/src/BinaryBytes/Utilities.cs
@@ -105,6 +105,7 @@ internal static class Utilities
             CompilandName = contributor.CompilandName,
             IsPGO = functionSymbol?.IsPGO ?? false,
             IsOptimizedForSpeed = functionSymbol?.IsOptimizedForSpeed ?? false,
+            DynamicInstructionCount = functionSymbol?.DynamicInstructionCount ?? 0,
         };
     }
 

--- a/src/SizeBench.AnalysisEngine/DIAInterop/DIAAdapter.cs
+++ b/src/SizeBench.AnalysisEngine/DIAInterop/DIAAdapter.cs
@@ -938,6 +938,7 @@ internal sealed class DIAAdapter : IDIAAdapter, IDisposable
         var isSealed = primaryBlockSymbol.@sealed != 0;
         var isPGO = primaryBlockSymbol.isPGO != 0;
         var isOptimizedForSpeed = primaryBlockSymbol.isOptimizedForSpeed != 0;
+        var dynamicInstructionCount = isPGO && primaryBlockSymbol.hasValidPGOCounts ==1 ? primaryBlockSymbol.PGODynamicInstructionCount : 0;
 
         if (separatedBlocks is null)
         {
@@ -949,7 +950,8 @@ internal sealed class DIAAdapter : IDIAAdapter, IDisposable
                                                 isVirtual: isVirtual,
                                                 isSealed: isSealed,
                                                 isPGO: isPGO,
-                                                isOptimizedForSpeed: isOptimizedForSpeed);
+                                                isOptimizedForSpeed: isOptimizedForSpeed,
+                                                dynamicInstructionCount: dynamicInstructionCount);
         }
         else
         {
@@ -973,7 +975,8 @@ internal sealed class DIAAdapter : IDIAAdapter, IDisposable
                                                  isVirtual: isVirtual,
                                                  isSealed: isSealed,
                                                  isPGO: isPGO,
-                                                 isOptimizedForSpeed: isOptimizedForSpeed);
+                                                 isOptimizedForSpeed: isOptimizedForSpeed,
+                                                 dynamicInstructionCount: dynamicInstructionCount);
         }
     }
 

--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Symbols/ComplexFunctionCodeSymbol.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Symbols/ComplexFunctionCodeSymbol.cs
@@ -16,6 +16,7 @@ public sealed class ComplexFunctionCodeSymbol : IFunctionCodeSymbol
     public bool IsSealed { get; }
     public bool IsPGO { get; }
     public bool IsOptimizedForSpeed { get; }
+    public ulong DynamicInstructionCount { get; }
 
     [Display(Name = "Function Type")]
     public FunctionTypeSymbol? FunctionType { get; }
@@ -52,7 +53,8 @@ public sealed class ComplexFunctionCodeSymbol : IFunctionCodeSymbol
                                        bool isVirtual = false,
                                        bool isSealed = false,
                                        bool isPGO = false,
-                                       bool isOptimizedForSpeed = false)
+                                       bool isOptimizedForSpeed = false,
+                                       ulong dynamicInstructionCount = 0)
     {
 #if DEBUG
         Debug.Assert(cache.SymbolSourcesSupported.HasFlag(SymbolSourcesSupported.Code));
@@ -77,6 +79,7 @@ public sealed class ComplexFunctionCodeSymbol : IFunctionCodeSymbol
         this.IsSealed = isSealed;
         this.IsPGO = isPGO;
         this.IsOptimizedForSpeed = isOptimizedForSpeed;
+        this.DynamicInstructionCount = dynamicInstructionCount;
         FunctionSymbolHelper.VerifyNotInInconsistentState(this);
 
         this.FunctionType = functionType;

--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Symbols/IFunctionCodeSymbol.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Symbols/IFunctionCodeSymbol.cs
@@ -20,6 +20,7 @@ public interface IFunctionCodeSymbol
     bool IsSealed { get; }
     bool IsPGO { get; }
     bool IsOptimizedForSpeed { get; }
+    ulong DynamicInstructionCount { get; }
 
     FunctionTypeSymbol? FunctionType { get; }
     IReadOnlyList<ParameterDataSymbol>? ArgumentNames { get; }

--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Symbols/SimpleFunctionCodeSymbol.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Symbols/SimpleFunctionCodeSymbol.cs
@@ -20,6 +20,7 @@ public sealed class SimpleFunctionCodeSymbol : CodeBlockSymbol, IFunctionCodeSym
     public bool IsSealed { get; }
     public bool IsPGO { get; }
     public bool IsOptimizedForSpeed { get; }
+    public ulong DynamicInstructionCount { get; }
 
     [Display(Name = "Function Type")]
     public FunctionTypeSymbol? FunctionType { get; }
@@ -57,7 +58,8 @@ public sealed class SimpleFunctionCodeSymbol : CodeBlockSymbol, IFunctionCodeSym
                                       bool isVirtual = false,
                                       bool isSealed = false,
                                       bool isPGO = false,
-                                      bool isOptimizedForSpeed = false) : base(cache, rva, size, symIndexId: symIndexId)
+                                      bool isOptimizedForSpeed = false,
+                                      ulong dynamicInstructionCount = 0) : base(cache, rva, size, symIndexId: symIndexId)
     {
 #if DEBUG
         Debug.Assert(cache.SymbolSourcesSupported.HasFlag(SymbolSourcesSupported.Code));
@@ -78,6 +80,7 @@ public sealed class SimpleFunctionCodeSymbol : CodeBlockSymbol, IFunctionCodeSym
         this.IsSealed = isSealed;
         this.IsPGO = isPGO;
         this.IsOptimizedForSpeed = isOptimizedForSpeed;
+        this.DynamicInstructionCount = dynamicInstructionCount;
         FunctionSymbolHelper.VerifyNotInInconsistentState(this);
 
         this.FunctionType = functionType;
@@ -100,6 +103,7 @@ public sealed class SimpleFunctionCodeSymbol : CodeBlockSymbol, IFunctionCodeSym
         }
 
         cache.AllFunctionSymbolsBySymIndexIdOfPrimaryBlock.Add(symIndexId, this);
+        this.DynamicInstructionCount = dynamicInstructionCount;
     }
 
     public override bool IsVeryLikelyTheSameAs(ISymbol otherSymbol)

--- a/src/SizeBench.GUI/Pages/Symbols/FunctionCodeSymbolDiffPage.xaml
+++ b/src/SizeBench.GUI/Pages/Symbols/FunctionCodeSymbolDiffPage.xaml
@@ -56,12 +56,8 @@
 
                 <StackPanel Grid.Row="3" Grid.ColumnSpan="2">
                     <TextBlock TextWrapping="Wrap">
-                        <Run>Functions can be complex and composed of multiple things - the code in them, of course, but functions also create data in many
-                        cases.  This page shows only the function's code.</Run>
-                        <LineBreak/>
-                        <Run>SizeBench currently does not attempt to account for the size of inlines - so if this function was inlined at multiple callsites,
-                        those costs are not added up here.  Thus, you can think of the total size shown, and the list of blocks of code below, as a lower
-                        bound for the total cost of this function if you were able to delete it in its entirety.</Run>
+                        Functions can be complex and composed of multiple things - the code in them, of course, but functions also create data in many
+                        cases.  This page shows only the function's code.
                     </TextBlock>
 
                     <TextBlock TextWrapping="Wrap" Margin="5">

--- a/src/SizeBench.GUI/Pages/Symbols/FunctionCodeSymbolDiffPageViewModel.cs
+++ b/src/SizeBench.GUI/Pages/Symbols/FunctionCodeSymbolDiffPageViewModel.cs
@@ -330,6 +330,11 @@ internal sealed class FunctionCodeSymbolDiffPageViewModel : BinaryDiffViewModelB
         if (function.IsPGO)
         {
             attributes.Add("has been PGO'd");
+
+            if (function.DynamicInstructionCount > 0)
+            {
+                attributes.Add($"has PGO dynamic instruction count of {function.DynamicInstructionCount:N0}");
+            }
         }
 
         if (function.IsOptimizedForSpeed)

--- a/src/SizeBench.GUI/Pages/Symbols/FunctionSymbolPage.xaml
+++ b/src/SizeBench.GUI/Pages/Symbols/FunctionSymbolPage.xaml
@@ -78,12 +78,8 @@
                 <StackPanel>
                     <TextBlock TextWrapping="Wrap" Width="{Binding ViewportWidth, ElementName=scroller}"
                                HorizontalAlignment="Left">
-                        <Run>Functions can be complex and composed of multiple things - the code in them, of course, but functions also create data in many
-                        cases.  This page shows only the function's code.</Run>
-                        <LineBreak/>
-                        <Run>SizeBench currently does not attempt to account for the size of inlines - so if this function was inlined at multiple callsites,
-                        those costs are not added up here.  Thus, you can think of the total size shown above, and the list of blocks of code below, as a lower
-                        bound for the total cost of this function if you were able to delete it in its entirety.</Run>
+                        Functions can be complex and composed of multiple things - the code in them, of course, but functions also create data in many
+                        cases.  This page shows only the function's code.
                     </TextBlock>
 
                     <Expander Header="Code blocks" IsExpanded="True" Width="{Binding ViewportWidth, ElementName=scroller}"

--- a/src/SizeBench.GUI/Pages/Symbols/FunctionSymbolPageViewModel.cs
+++ b/src/SizeBench.GUI/Pages/Symbols/FunctionSymbolPageViewModel.cs
@@ -158,6 +158,11 @@ internal sealed class FunctionSymbolPageViewModel : SingleBinaryViewModelBase
         if (this.Function.IsPGO)
         {
             attributes.Add("has been PGO'd");
+
+            if (this.Function.DynamicInstructionCount > 0)
+            {
+                attributes.Add($"has PGO dynamic instruction count of {this.Function.DynamicInstructionCount:N0}");
+            }
         }
 
         if (this.Function.IsOptimizedForSpeed)


### PR DESCRIPTION
## Why is this change being made?
BinaryBytes usability went down when adding inline site information, as I denormalized the database to improve the on-disk size and build time of the database.  This adds SQL VIEWs to the database that are as usable as the old tables (or moreso), without incurring additional time or space to build the database.

While in here I also noticed that the PGO Dynamic Instruction Count wasn't being threaded through to BinaryBytes.  It used to be in an earlier internal private branch, so I'm moving that to the public version.

## Briefly summarize what changed
- Added PGO Dynamic Instruction Count to `IFunctionCodeSymbol` for both simple and complex functions and threading it through to BinaryBytes and the GUI.
- Added SQL views to increase usability of BinaryBytes.

## How was the change tested?
Manually ran BinaryBytes on a large binary and confirmed the output seems correct.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* ~[ ] Documentation updated. Please add or update any docs in the repo as necessary.~