### PR TITLE
Some binaries fail to open due to multiple Compiland SymIndexIDs mapping to one Compiland object, and also a small About Box fix for the GUI

### DIFF
--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Diffs/CompilandDiff.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Diffs/CompilandDiff.cs
@@ -42,16 +42,31 @@ public sealed class CompilandDiff
         }
     }
 
+#if DEBUG
+    private static bool SymIndexIDListsAreEquivalent(Compiland a, Compiland b)
+    {
+        foreach (var symIndexId in a.SymIndexIds)
+        {
+            if (!b.SymIndexIds.Contains(symIndexId))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+#endif
+
     internal CompilandDiff(Compiland? before, Compiland? after, LibDiff libDiff, List<BinarySectionDiff> sectionDiffs, DiffSessionDataCache cache)
     {
 #if DEBUG
         // As with (non-diff) Compilands, "Import:<anything>" can be special and appear multiple times in a binary by name.
         // Thus the more complex check here than just the names.
         if (cache.CompilandDiffsConstructedEver.Any(cd =>
-        {
-            return (before != null && cd.BeforeCompiland != null && cd.BeforeCompiland.SymIndexId == before.SymIndexId) ||
-                   (after != null && cd.AfterCompiland != null && cd.AfterCompiland.SymIndexId == after.SymIndexId);
-        }) ||
+            {
+                return (before is not null && cd.BeforeCompiland is not null && SymIndexIDListsAreEquivalent(cd.BeforeCompiland, before)) ||
+                       (after is not null && cd.AfterCompiland is not null && SymIndexIDListsAreEquivalent(cd.AfterCompiland, after));
+            }) ||
             cache.CompilandDiffsConstructedEver.Any(cd => cd.Name == (before?.Name ?? after?.Name) &&
                                                           cd.LibDiff.Name == (before?.Lib.Name ?? after?.Lib.Name)))
         {

--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Compiland.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Compiland.cs
@@ -174,6 +174,8 @@ public sealed class Compiland : IEquatable<Compiland>
 
     internal Compiland(SessionDataCache cache, string name, Library lib, CommandLine commandLine, uint compilandSymIndex)
     {
+        name = String.IsNullOrEmpty(name) ? UnknownName : name;
+
 #if DEBUG
         // Compilands that start with "Import:" are sort of special, since they can exist multiple times in a binary
         // and that's fine.
@@ -188,7 +190,7 @@ public sealed class Compiland : IEquatable<Compiland>
         }
 #endif
 
-        this.Name = String.IsNullOrEmpty(name) ? UnknownName : name;
+        this.Name = name;
         this._commandLine = commandLine;
         this.SymIndexId = compilandSymIndex;
         this.Lib = lib;

--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Compiland.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Compiland.cs
@@ -15,7 +15,7 @@ public sealed class Compiland : IEquatable<Compiland>
 
     private bool _fullyConstructed;
 
-    internal readonly uint SymIndexId;
+    internal readonly HashSet<uint> SymIndexIds = new HashSet<uint>();
 
     public string Name { get; }
 
@@ -182,7 +182,7 @@ public sealed class Compiland : IEquatable<Compiland>
         // Technically, what maks a Compiland unique is the compilandId, but for most users this is difficult to visually
         // parse so we hope that most binaries only have compilands that are unique by name (including the name of the lib
         // they're part of) - note that name is a fully-qualified path, so that's not too crazy to assume.
-        if (cache.CompilandsConstructedEver.Any(c => c.SymIndexId == compilandSymIndex) ||
+        if (cache.CompilandsConstructedEver.Any(c => c.SymIndexIds.Contains(compilandSymIndex)) ||
             cache.CompilandsConstructedEver.Any(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase) &&
                                                      c.Lib.Name.Equals(lib.Name, StringComparison.OrdinalIgnoreCase)))
         {
@@ -192,10 +192,20 @@ public sealed class Compiland : IEquatable<Compiland>
 
         this.Name = name;
         this._commandLine = commandLine;
-        this.SymIndexId = compilandSymIndex;
+        this.SymIndexIds.Add(compilandSymIndex);
         this.Lib = lib;
 
-        cache.RecordCompilandConstructed(this);
+        cache.RecordCompilandConstructed(this, compilandSymIndex);
+    }
+
+    internal void AddSymIndexId(uint compilandSymIndex)
+    {
+        if (this._fullyConstructed)
+        {
+            throw new ObjectFullyConstructedAlreadyException();
+        }
+
+        this.SymIndexIds.Add(compilandSymIndex);
     }
 
     internal CompilandSectionContribution GetOrCreateSectionContribution(BinarySection section)

--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Library.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Library.cs
@@ -81,6 +81,7 @@ public sealed class Library : IEquatable<Library>
 
         if (this._compilands.TryGetValue(compilandName, out var existingCompiland))
         {
+            cache.RecordAdditionalSymIndexIdForCompiland(existingCompiland, compilandSymIndexId);
             return existingCompiland;
         }
 

--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Library.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/Library.cs
@@ -74,6 +74,11 @@ public sealed class Library : IEquatable<Library>
             throw new ObjectFullyConstructedAlreadyException();
         }
 
+        if (String.IsNullOrEmpty(compilandName))
+        {
+            compilandName = Compiland.UnknownName;
+        }
+
         if (this._compilands.TryGetValue(compilandName, out var existingCompiland))
         {
             return existingCompiland;

--- a/src/SizeBench.GUI/Windows/AboutBox.xaml
+++ b/src/SizeBench.GUI/Windows/AboutBox.xaml
@@ -68,7 +68,7 @@
                         </Hyperlink>
                     </Label>
                     <Label Style="{StaticResource LinkLabelStyle}">
-                        <Hyperlink NavigateUri="https://github.com/microsoft/SizeBench/blob/main/docs/Contributing.md"
+                        <Hyperlink NavigateUri="https://github.com/microsoft/SizeBench/blob/main/CONTRIBUTING.md"
                                    Style="{StaticResource LinkLabelStyle}">
                             <i:Interaction.Behaviors>
                                 <navigationControls:ExternalHyperlinkNavigationBehavior/>


### PR DESCRIPTION
## Why is this change being made?
A customer reported that their binary could not be opened in SizeBench.

## Briefly summarize what changed
Multiple `SymIndexID` values from DIA can map to the same SizeBench `Compiland` object (such as the null string and empty string).  So, much like I did with source files recently, change `Compiland` entities to hold multiple SymIndexIDs and make the 1:many relationship work in all the places it needs to.

While I was in here it is convenient to also fix #36 where the About Box had a bad link in it since it's so trivial, so I did that.

Fixes #36 

## How was the change tested?
Manually with the customer's binary.  And ran all the existing tests.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* ~[ ] Documentation updated. Please add or update any docs in the repo as necessary.~