### PR TITLE
Fixing a couple bugs seen when running SizeBench on lots and lots of binaries

### DIFF
--- a/src/SizeBench.AnalysisEngine/DIAInterop/IDIAAdapter.cs
+++ b/src/SizeBench.AnalysisEngine/DIAInterop/IDIAAdapter.cs
@@ -37,4 +37,5 @@ internal interface IDIAAdapter
     CompilandLanguage LanguageOfSymbolAtRva(uint rva);
 
     uint? LoadPublicSymbolTargetRVAIfPossible(uint rva);
+    List<IMAGE_SECTION_HEADER> FindAllImageSectionHeadersFromPDB(CancellationToken token);
 }

--- a/src/SizeBench.AnalysisEngine/PE/PInvokes.cs
+++ b/src/SizeBench.AnalysisEngine/PE/PInvokes.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Security;
 
@@ -514,6 +515,252 @@ internal readonly struct IMAGE_THUNK_DATA64
 
     [FieldOffset(0)]
     public readonly ulong AddressOfData;
+}
+
+[ExcludeFromCodeCoverage]
+[DebuggerDisplay("Section={Section}, SizeOfRawData={SizeOfRawData}")]
+[StructLayout(LayoutKind.Explicit)]
+internal readonly struct IMAGE_SECTION_HEADER
+{
+    [FieldOffset(0)]
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+    public readonly char[] Name;
+
+    [FieldOffset(8)]
+    public readonly uint VirtualSize;
+
+    [FieldOffset(12)]
+    public readonly uint VirtualAddress;
+
+    [FieldOffset(16)]
+    public readonly uint SizeOfRawData;
+
+    [FieldOffset(20)]
+    public readonly uint PointerToRawData;
+
+    [FieldOffset(24)]
+    public readonly uint PointerToRelocations;
+
+    [FieldOffset(28)]
+    public readonly uint PointerToLinenumbers;
+
+    [FieldOffset(32)]
+    public readonly ushort NumberOfRelocations;
+
+    [FieldOffset(34)]
+    public readonly ushort NumberOfLinenumbers;
+
+    [FieldOffset(36)]
+    public readonly DataSectionFlags Characteristics;
+
+    public string Section
+    {
+        get
+        {
+            var nameString = new string(this.Name);
+            if (nameString.Contains('\0', StringComparison.Ordinal))
+            {
+                nameString = nameString[..nameString.IndexOf('\0', StringComparison.Ordinal)];
+            }
+
+            return nameString;
+        }
+    }
+
+    public IMAGE_SECTION_HEADER(IMAGE_SECTION_HEADER original, string newName)
+    {
+        this.Name = newName.ToCharArray();
+        this.VirtualSize = original.VirtualSize;
+        this.VirtualAddress = original.VirtualAddress;
+        this.SizeOfRawData = original.SizeOfRawData;
+        this.PointerToRawData = original.PointerToRawData;
+        this.PointerToRelocations = original.PointerToRelocations;
+        this.PointerToLinenumbers = original.PointerToLinenumbers;
+        this.NumberOfRelocations = original.NumberOfRelocations;
+        this.NumberOfLinenumbers = original.NumberOfLinenumbers;
+        this.Characteristics = original.Characteristics;
+    }
+}
+
+[Flags]
+#pragma warning disable CA1028 // Enum Storage should be Int32 - this is for interop purposes with DIA, and in DIA it is an unsigned int
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - "DataSectionFlags" is the name in the PE spec, so ignoring this rule
+public enum DataSectionFlags : uint
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+#pragma warning restore CA1028 // Enum Storage should be Int32
+{
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+#pragma warning disable CA1008 // Enums should have zero value - this is a well documented named part of the PE file format, the name should be exactly as it is in the PE spec.
+    TypeReg = 0x00000000,
+#pragma warning restore CA1008 // Enums should have zero value
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    TypeDsect = 0x00000001,
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    TypeNoLoad = 0x00000002,
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    TypeGroup = 0x00000004,
+    /// <summary>
+    /// The section should not be padded to the next boundary. This flag is obsolete and is replaced by IMAGE_SCN_ALIGN_1BYTES. This is valid only for object files.
+    /// </summary>
+    TypeNoPadded = 0x00000008,
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    TypeCopy = 0x00000010,
+    /// <summary>
+    /// The section contains executable code.
+    /// </summary>
+    ContentCode = 0x00000020,
+    /// <summary>
+    /// The section contains initialized data.
+    /// </summary>
+    ContentInitializedData = 0x00000040,
+    /// <summary>
+    /// The section contains uninitialized data.
+    /// </summary>
+    ContentUninitializedData = 0x00000080,
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    LinkOther = 0x00000100,
+    /// <summary>
+    /// The section contains comments or other information. The .drectve section has this type. This is valid for object files only.
+    /// </summary>
+    LinkInfo = 0x00000200,
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    TypeOver = 0x00000400,
+    /// <summary>
+    /// The section will not become part of the image. This is valid only for object files.
+    /// </summary>
+    LinkRemove = 0x00000800,
+    /// <summary>
+    /// The section contains COMDAT data. For more information, see section 5.5.6, COMDAT Sections (Object Only). This is valid only for object files.
+    /// </summary>
+    LinkComDat = 0x00001000,
+    /// <summary>
+    /// Reset speculative exceptions handling bits in the TLB entries for this section.
+    /// </summary>
+    NoDeferSpecExceptions = 0x00004000,
+    /// <summary>
+    /// The section contains data referenced through the global pointer (GP).
+    /// </summary>
+    RelativeGP = 0x00008000,
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    MemPurgeable = 0x00020000,
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+#pragma warning disable CA1069 // Enums values should not be duplicated - this is an enum defined in the PE spec, not something I can control
+    Memory16Bit = 0x00020000,
+#pragma warning restore CA1069 // Enums values should not be duplicated
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    MemoryLocked = 0x00040000,
+    /// <summary>
+    /// Reserved for future use.
+    /// </summary>
+    MemoryPreload = 0x00080000,
+    /// <summary>
+    /// Align data on a 1-byte boundary. Valid only for object files.
+    /// </summary>
+    Align1Bytes = 0x00100000,
+    /// <summary>
+    /// Align data on a 2-byte boundary. Valid only for object files.
+    /// </summary>
+    Align2Bytes = 0x00200000,
+    /// <summary>
+    /// Align data on a 4-byte boundary. Valid only for object files.
+    /// </summary>
+    Align4Bytes = 0x00300000,
+    /// <summary>
+    /// Align data on an 8-byte boundary. Valid only for object files.
+    /// </summary>
+    Align8Bytes = 0x00400000,
+    /// <summary>
+    /// Align data on a 16-byte boundary. Valid only for object files.
+    /// </summary>
+    Align16Bytes = 0x00500000,
+    /// <summary>
+    /// Align data on a 32-byte boundary. Valid only for object files.
+    /// </summary>
+    Align32Bytes = 0x00600000,
+    /// <summary>
+    /// Align data on a 64-byte boundary. Valid only for object files.
+    /// </summary>
+    Align64Bytes = 0x00700000,
+    /// <summary>
+    /// Align data on a 128-byte boundary. Valid only for object files.
+    /// </summary>
+    Align128Bytes = 0x00800000,
+    /// <summary>
+    /// Align data on a 256-byte boundary. Valid only for object files.
+    /// </summary>
+    Align256Bytes = 0x00900000,
+    /// <summary>
+    /// Align data on a 512-byte boundary. Valid only for object files.
+    /// </summary>
+    Align512Bytes = 0x00A00000,
+    /// <summary>
+    /// Align data on a 1024-byte boundary. Valid only for object files.
+    /// </summary>
+    Align1024Bytes = 0x00B00000,
+    /// <summary>
+    /// Align data on a 2048-byte boundary. Valid only for object files.
+    /// </summary>
+    Align2048Bytes = 0x00C00000,
+    /// <summary>
+    /// Align data on a 4096-byte boundary. Valid only for object files.
+    /// </summary>
+    Align4096Bytes = 0x00D00000,
+    /// <summary>
+    /// Align data on an 8192-byte boundary. Valid only for object files.
+    /// </summary>
+    Align8192Bytes = 0x00E00000,
+    /// <summary>
+    /// The section contains extended relocations.
+    /// </summary>
+    LinkExtendedRelocationOverflow = 0x01000000,
+    /// <summary>
+    /// The section can be discarded as needed.
+    /// </summary>
+    MemoryDiscardable = 0x02000000,
+    /// <summary>
+    /// The section cannot be cached.
+    /// </summary>
+    MemoryNotCached = 0x04000000,
+    /// <summary>
+    /// The section is not pageable.
+    /// </summary>
+    MemoryNotPaged = 0x08000000,
+    /// <summary>
+    /// The section can be shared in memory.
+    /// </summary>
+    MemoryShared = 0x10000000,
+    /// <summary>
+    /// The section can be executed as code.
+    /// </summary>
+    MemoryExecute = 0x20000000,
+    /// <summary>
+    /// The section can be read.
+    /// </summary>
+    MemoryRead = 0x40000000,
+    /// <summary>
+    /// The section can be written to.
+    /// </summary>
+    MemoryWrite = 0x80000000
 }
 
 internal static class CFGConstants

--- a/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/COFFGroup.cs
+++ b/src/SizeBench.AnalysisEngine/SessionManagedObjects/Single Binary/COFFGroup.cs
@@ -11,7 +11,7 @@ public sealed class COFFGroup
     {
         get
         {
-            if (this._fullyConstructed)
+            if (this.IsFullyConstructed)
             {
                 return $"COFF Group: {this.Name}, Section={this.Section?.Name ?? "<none set>"} Size={this.Size:N0}, VirtualSize={this.VirtualSize:N0}, RVA=0x{this.RVA:X}";
             }
@@ -22,7 +22,7 @@ public sealed class COFFGroup
         }
     }
 
-    private bool _fullyConstructed;
+    internal bool IsFullyConstructed { get; private set; }
 
     public string Name { get; }
 
@@ -42,7 +42,7 @@ public sealed class COFFGroup
             // You should not use RawSize past initial construction time - it's a parking
             // ground for the size until we can determine if it's real or virtual.
             // Post-construction-time you should always use Size or VirtualSize.
-            if (this._fullyConstructed)
+            if (this.IsFullyConstructed)
             {
                 throw new ObjectFullyConstructedAlreadyException();
             }
@@ -66,7 +66,7 @@ public sealed class COFFGroup
     {
         get
         {
-            if (!this._fullyConstructed || !this._tailSlopSizeAlignment.HasValue)
+            if (!this.IsFullyConstructed || !this._tailSlopSizeAlignment.HasValue)
             {
                 throw new ObjectNotYetFullyConstructedException();
             }
@@ -90,7 +90,7 @@ public sealed class COFFGroup
     {
         get
         {
-            if (!this._fullyConstructed)
+            if (!this.IsFullyConstructed)
             {
                 throw new ObjectNotYetFullyConstructedException();
             }
@@ -116,7 +116,7 @@ public sealed class COFFGroup
     {
         get
         {
-            if (!this._fullyConstructed)
+            if (!this.IsFullyConstructed)
             {
                 throw new ObjectNotYetFullyConstructedException();
             }
@@ -132,7 +132,7 @@ public sealed class COFFGroup
     {
         get
         {
-            if (!this._fullyConstructed)
+            if (!this.IsFullyConstructed)
             {
                 throw new ObjectNotYetFullyConstructedException();
             }
@@ -146,7 +146,7 @@ public sealed class COFFGroup
     {
         get
         {
-            if (!this._fullyConstructed)
+            if (!this.IsFullyConstructed)
             {
                 throw new ObjectNotYetFullyConstructedException();
             }
@@ -164,7 +164,7 @@ public sealed class COFFGroup
     {
         get
         {
-            if (!this._fullyConstructed)
+            if (!this.IsFullyConstructed)
             {
                 throw new ObjectNotYetFullyConstructedException();
             }
@@ -173,7 +173,7 @@ public sealed class COFFGroup
         }
         internal set
         {
-            if (this._fullyConstructed)
+            if (this.IsFullyConstructed)
             {
                 throw new ObjectFullyConstructedAlreadyException();
             }
@@ -223,6 +223,6 @@ public sealed class COFFGroup
             this._size = this.RawSize;
         }
 
-        this._fullyConstructed = true;
+        this.IsFullyConstructed = true;
     }
 }

--- a/src/SizeBench.SKUCrawler/Program.cs
+++ b/src/SizeBench.SKUCrawler/Program.cs
@@ -527,6 +527,7 @@ internal static class Program
                                 "BinaryID INT NOT NULL, " +
                                 "ExceptionType TEXT, " +
                                 "ExceptionMessage TEXT, " +
+                                "ExceptionDetails TEXT, " +
                                 "CONSTRAINT fk_binaries " +
                                 "  FOREIGN KEY (BinaryID) " +
                                $"  REFERENCES {_BinariesTable}(BinaryID) " +
@@ -1131,20 +1132,22 @@ internal static class Program
         var reader = queryPerfStats.ExecuteReader();
 
         mergedCommand.CommandText = $"INSERT INTO {_ErrorsTableName} " +
-                                     "(BinaryID, ExceptionType, ExceptionMessage) " +
+                                     "(BinaryID, ExceptionType, ExceptionMessage, ExceptionDetails) " +
                                      "VALUES " +
-                                     "(@BinaryID, @ExceptionType, @ExceptionMessage)";
+                                     "(@BinaryID, @ExceptionType, @ExceptionMessage, @ExceptionDetails)";
 
         mergedCommand.Parameters.Clear();
         mergedCommand.Parameters.AddWithValue("@BinaryID", 0);
         mergedCommand.Parameters.AddWithValue("@ExceptionType", String.Empty);
         mergedCommand.Parameters.AddWithValue("@ExceptionMessage", String.Empty);
+        mergedCommand.Parameters.AddWithValue("@ExceptionDetails", String.Empty);
 
         while (reader.Read())
         {
             mergedCommand.Parameters["@BinaryID"].Value = binaryIDMappings[Convert.ToInt32(reader["BinaryID"], CultureInfo.InvariantCulture)];
             mergedCommand.Parameters["@ExceptionType"].Value = reader["ExceptionType"];
             mergedCommand.Parameters["@ExceptionMessage"].Value = reader["ExceptionMessage"];
+            mergedCommand.Parameters["@ExceptionDetails"].Value = reader["ExceptionDetails"];
             mergedCommand.ExecuteNonQuery();
         }
     }

--- a/src/SizeBench.TestDataCommon/TestDIAAdapter.cs
+++ b/src/SizeBench.TestDataCommon/TestDIAAdapter.cs
@@ -308,4 +308,7 @@ internal class TestDIAAdapter : IDIAAdapter
 
     public uint? LoadPublicSymbolTargetRVAIfPossible(uint rva)
         => throw new NotImplementedException();
+
+    public List<IMAGE_SECTION_HEADER> FindAllImageSectionHeadersFromPDB(CancellationToken token) 
+        => throw new NotImplementedException();
 }


### PR DESCRIPTION
## Why is this change being made?
When running a much more rigorous selection of binaries through SizeBench I've found a couple bugs to fix.

## Briefly summarize what changed
1. When reading in the COFF Groups from a binary, it seems sometimes they can be bogus and we can find a COFF Group with no containing Section.  This used to work (before this PR: #29) because we'd read in the `"SECTIONHEADERS"` debug stream from the PDB and the PDB happened to match the COFF Group table written to the binary.  But when I changed to reading the section headers with the `System.Reflection.PortableExecutable` library it's reading the sections from the PE file itself which is generally a good thing.  So, we keep that code but now have a fallback to consult the PDB `"SECTIONHEADERS"` stream to try to find a containing section.
2. When parsing the DOS and NT headers for a binary I was reading in the first 4k bytes and trying to read both.  In most binaries this is great because they end up together - but if a binary uses a custom DOS stub (by using `/stub:` on the MSVC link.exe command line for example) they can put arbitrarily large programs between the DOS header and NT header and that can mean the NT header is >4k bytes into the binary.  So, we should seek to the NT header location and read in more data instead of assuming they're in the same first 4k of the binary.  This also regressed with #29 
3. When using SKUCrawler, if it happens to discover a separated block for a function before the primary block for the function, it was mutating a collection while iterating over it which would throw - we should instead not modify the collection we're enumerating and just note which primary blocks should be ignored when found later in the walk.

## How was the change tested?
Used the existing test suite and a couple of manual runs across a very large scale of binaries that is impractical to run in SizeBench CI.
 
## PR Checklist
* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* [ ] ~Documentation updated. Please add or update any docs in the repo as necessary.~