### PR TITLE
Allow file drag-and-drop

### DIFF
--- a/src/SizeBench.GUI/Windows/SelectSingleBinaryAndPDBControl.xaml
+++ b/src/SizeBench.GUI/Windows/SelectSingleBinaryAndPDBControl.xaml
@@ -1,11 +1,13 @@
 ﻿<UserControl x:Class="SizeBench.GUI.Windows.SelectSingleBinaryAndPDBControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             mc:Ignorable="d" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
              d:DesignWidth="500">
-    <Grid>
+    <Grid AllowDrop="True "
+          PreviewDragOver="OnDragOver"
+          PreviewDrop="OnDrop">
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
             <ColumnDefinition/>

--- a/src/SizeBench.GUI/Windows/SelectSingleBinaryAndPDBControl.xaml.cs
+++ b/src/SizeBench.GUI/Windows/SelectSingleBinaryAndPDBControl.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Win32;
@@ -55,5 +56,94 @@ public partial class SelectSingleBinaryAndPDBControl : UserControl
         {
             this._viewModel!.BinaryPath = ofd.FileName;
         }
+    }
+
+    private void OnDragOver(object sender, DragEventArgs e)
+    {
+        e.Effects = GetDroppedExeAndPdb(e.Data) is null ? DragDropEffects.None : DragDropEffects.Copy;
+        e.Handled = true;
+    }
+
+    private static (string, string)? GetDroppedExeAndPdb(IDataObject data)
+    {
+        if (!data.GetDataPresent(DataFormats.FileDrop))
+        {
+            return null;
+        }
+
+        var files = (data.GetData(DataFormats.FileDrop) as string[])!;
+
+        if (files.Length is < 0 or > 2)
+        {
+            return null;
+        }
+
+        string? exePath = null;
+        string? pdbPath = null;
+        foreach (var file in files)
+        {
+            if (file.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                exePath = file;
+            }
+            else if (file.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
+            {
+                pdbPath = file;
+            }
+        }
+
+        if (exePath is null && pdbPath is null)
+        {
+            return null;
+        }
+
+        if (exePath is not null && pdbPath is not null)
+        {
+            return (exePath, pdbPath);
+        }
+
+        if (files.Length != 1)
+        {
+            return null;
+        }
+
+        if (exePath is not null)
+        {
+            pdbPath = exePath[..^3] + "pdb";
+            if (File.Exists(pdbPath))
+            {
+                return (exePath, pdbPath);
+            }
+
+            return null;
+        }
+
+        if (pdbPath is not null)
+        {
+            exePath = pdbPath[..^3] + "exe";
+            if (File.Exists(exePath))
+            {
+                return (exePath, pdbPath);
+            }
+        }
+
+        return null;
+    }
+
+    private void OnDrop(object sender, DragEventArgs e)
+    {
+        var exeAndPdb = GetDroppedExeAndPdb(e.Data);
+        if (exeAndPdb is null)
+        {
+            e.Effects = DragDropEffects.None;
+            e.Handled = true;
+            return;
+        }
+
+        var (exePath, pdbPath) = exeAndPdb.Value;
+        this._viewModel!.PDBPath = pdbPath;
+        this._viewModel!.BinaryPath = exePath;
+        e.Effects = DragDropEffects.Copy;
+        e.Handled = true;
     }
 }


### PR DESCRIPTION
## Why is this change being made?

Just a small ease-of-use improvement. Because of other dev tools, I mostly expected this to work.

## Briefly summarize what changed

Executable and PDB files can be dragged into the 'Examine a binary' and 'Start a diff' windows.

I took a brief look at also supporting dragging on to the 'Welcome to SizeBench' pane, but not familiar enough with WPF to figure out a clean way to do that with the routed UI Commands.

## How was the change tested?

Dragged my exe and PDB into the 'open single binary' controls, clicked OK, sizebench opened it up

Dragged them separately into before and after in the diff window, only the dropped control was popuplated.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* [x] Documentation updated. Please add or update any docs in the repo as necessary.