### PR TITLE
Fix the issue seen with block overlaps in some LLD-linked binaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ tools, at a minimum. You'll also need to install these additional _Individual co
  - Windows 10 SDK (10.0.15063.0) for Desktop C++ [x86 and x64]. This can be downloaded from 
    [here](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) if it does not 
    show up in your version of the Visual Studio Installer.
- - Windows 10 SDK (10.0.20348.0). This contains the support for building the MSIX packaging project.
+ - Windows 10 SDK (10.0.26100.0). This contains the support for building the MSIX packaging project.
 
 Once you open the SizeBench.sln Solution, you should build it once to be sure everything seems to be set
 up right.  If you hit issues, file an issue and we'll help you out. Then, do the following:

--- a/src/BinaryBytes/Program.cs
+++ b/src/BinaryBytes/Program.cs
@@ -248,7 +248,7 @@ public static class Program
     /// Given a COFF group and a list of symbols in that group, this routine identifies all the Padding bytes and
     /// the actual symbols bytes in the COFF group and marks them appropriately.
     /// </summary>
-    private static void IdentifyPaddingAroundSymbols(IReadOnlyList<ISymbol> symbols, COFFGroup coffgroup, Dictionary<uint, SymbolContributor> rvaToContributorMap, List<BytesItem> bytesItems)
+    private static void IdentifyPaddingAroundSymbols(List<ISymbol> symbols, COFFGroup coffgroup, Dictionary<uint, SymbolContributor> rvaToContributorMap, List<BytesItem> bytesItems)
     {
         // Is there gap at the start of this COFF group?
         var startingByteOfCoffgroup = coffgroup.RVA;
@@ -279,7 +279,7 @@ public static class Program
 
         // Is there gap at the end of this COFF group?
         ulong endingByteOfCoffgroup = coffgroup.RVA + coffgroup.VirtualSize;
-        var endingByteOfLastSymbol = symbols[symbols.Count - 1].RVA + symbols[symbols.Count - 1].VirtualSize;
+        var endingByteOfLastSymbol = symbols[^1].RVA + symbols[^1].VirtualSize;
         if (endingByteOfCoffgroup != endingByteOfLastSymbol && endingByteOfCoffgroup > endingByteOfLastSymbol)
         {
             bytesItems.Add(Utilities.CreatePaddingBytesItem(Constants.CoffgroupEndPadding, coffgroup.Name,

--- a/src/SizeBench.AnalysisEngine/DIAInterop/DIAAdapter.cs
+++ b/src/SizeBench.AnalysisEngine/DIAInterop/DIAAdapter.cs
@@ -1119,15 +1119,16 @@ internal sealed class DIAAdapter : IDIAAdapter, IDisposable
             parentSymbol = parentSymbol.lexicalParent;
         }
 
+        IFunctionCodeSymbol function;
         if (parentSymbol != null && (SymTagEnum)parentSymbol.symTag == SymTagEnum.SymTagFunction)
         {
             // This will in turn parse all the blocks for the function
             // This may be a Complex function with primary and separated blocks (if MSVC arrived here),
             // or this may be a Simple function when clang generates code as it can generate a lone
             // SymTagBlock under a function.
-            var function = GetOrCreateFunctionSymbol(parentSymbol, cancellationToken);
+            function = GetOrCreateFunctionSymbol(parentSymbol, cancellationToken);
 
-            // If we found a simple function, we'll return it right away.  We only go further for MSVC
+            // If we found a simple function, we'll return it right away.  We only go further
             // when we need to find the block within the complex function.
             if (function is SimpleFunctionCodeSymbol simpleFn)
             {
@@ -1139,9 +1140,49 @@ internal sealed class DIAAdapter : IDIAAdapter, IDisposable
             throw new InvalidOperationException("We've found a separated block that does not have a function as its parent - how is this possible?  This is a bug in SizeBench's implementation, not your use of it.");
         }
 
-        var block = (CodeBlockSymbol)this.DataCache.AllSymbolsBySymIndexId[diaSymbol.symIndexId];
-        Debug.Assert(!String.IsNullOrEmpty(block.Name));
-        return block;
+        CodeBlockSymbol? parsedBlock = null;
+        if (this.DataCache.AllSymbolsBySymIndexId.TryGetValue(diaSymbol.symIndexId, out var existingBlock))
+        {
+            parsedBlock = (CodeBlockSymbol)existingBlock;
+        }
+        else
+        {
+            // In some cases, LLD has been seen to emit PDBs where functions can look like this:
+            // Primary Block: 0x25E94A-0x25EC39, with SymIndexId = X
+            //  findChildren for SymTagBlock on that SymTagFunction:
+            //    Separated Block: 0x25EBC9-0x25EC39 (fully overlaps with primary), with SymIndexId = Y
+            //    Separated Block: 0xE0741C0-0xE0741D1, with SymIndexId = Z
+            // Then we end up in this path and find a different block like this:
+            //    Block: 0x25EBDE-0x25EC39 (again fully overlaps with primary), with SymIndexId = A
+            //
+            // So, the problem is - we asked the function for all its child block symbols and we somehow didn't
+            // find this one, but it does in fact overlap with another block we *did* find.  This is *probably*
+            // a bug in LLD's PDB generation, but we'll try to compensate here by looking through all the blocks
+            // in the parent function we found, and if any of them fully contains this symbol, we'll just return
+            // that block.
+            var blockRangeToFind = RVARange.FromRVAAndSize(diaSymbol.relativeVirtualAddress, (uint)diaSymbol.length);
+            foreach (var block in function.Blocks)
+            {
+                var blockRange = new RVARange(block.RVA, block.RVAEnd);
+                if (blockRange.Contains(blockRangeToFind))
+                {
+                    // We'll just return this block instead of creating a new one that overlaps it.
+                    parsedBlock = block;
+                    // But we'll also cache this SymIndexId to point to this block so if anyone else looks it up
+                    // by SymIndexId they'll find the right thing.
+                    this.DataCache.AllSymbolsBySymIndexId[diaSymbol.symIndexId] = parsedBlock;
+                    break;
+                }
+            }
+        }
+
+        if (parsedBlock is null)
+        {
+            throw new InvalidOperationException($"Failed to parse block symbol for block with RVA=0x{diaSymbol.relativeVirtualAddress:X}, SymIndexID={diaSymbol.symIndexId}.");
+        }
+
+        Debug.Assert(!String.IsNullOrEmpty(parsedBlock.Name));
+        return parsedBlock;
     }
 
     private InlineSiteSymbol GetOrCreateInlineSiteSymbol(IDiaSymbol diaSymbol, CancellationToken cancellationToken)
@@ -1816,7 +1857,7 @@ internal sealed class DIAAdapter : IDIAAdapter, IDisposable
     {
         ThrowIfOnWrongThread();
 
-        ISymbol? previousNonFoldedSymbolYielded = null;
+        Symbol? previousNonFoldedSymbolYielded = null;
 
         if (this.DataCache.TryFindSymIndicesInRVARange(range, out var symIndicesByRVA, out var minIdx, out var maxIdx))
         {

--- a/src/SizeBench.AnalysisEngine/DiffSessionTasks/EnumerateLibsAndCompilandDiffsSessionTask.cs
+++ b/src/SizeBench.AnalysisEngine/DiffSessionTasks/EnumerateLibsAndCompilandDiffsSessionTask.cs
@@ -85,6 +85,7 @@ internal sealed class EnumerateLibsAndCompilandDiffsSessionTask : DiffSessionTas
             // First try matching on the name exactly
             var matchingAfterLib = afterLibsToProcess.FirstOrDefault(afterLib => String.Equals(beforeLib.Name, afterLib.Name, StringComparison.OrdinalIgnoreCase));
 
+#pragma warning disable IDE0270 // Use coalesce expression - this doesn't work because of the #if DEBUG part, so it hits in Release but is a mess to format for both flavors
             if (matchingAfterLib is null)
             {
                 // If that failed, try matching on IsVeryLikelyTheSameAs, which is more generous.  This two-phase attempt is unfortunately
@@ -113,6 +114,7 @@ internal sealed class EnumerateLibsAndCompilandDiffsSessionTask : DiffSessionTas
                 }
 #endif
             }
+#pragma warning restore IDE0270 // Use coalesce expression
 
             libDiffs.Add(new LibDiff(beforeLib, matchingAfterLib, this.DataCache.AllBinarySectionDiffs!, this.DataCache));
 

--- a/src/SizeBench.AnalysisEngine/SessionTasks/EnumerateLibsAndCompilandsSessionTask.cs
+++ b/src/SizeBench.AnalysisEngine/SessionTasks/EnumerateLibsAndCompilandsSessionTask.cs
@@ -92,7 +92,7 @@ internal sealed class EnumerateLibsAndCompilandsSessionTask : SessionTask<HashSe
     private void ParseSectionContrib(RawSectionContribution sectionContrib,
                                      Dictionary<string, Library> libs,
                                      HashSet<Compiland> compilands,
-                                     IReadOnlyList<COFFGroup> coffGroups)
+                                     List<COFFGroup> coffGroups)
     {
 
         // If this RVA range is inside the PDATA region, it is not going to be correct anyway.  There was a bug

--- a/src/SizeBench.AnalysisEngine/SessionTasks/EnumerateSourceFilesSessionTask.cs
+++ b/src/SizeBench.AnalysisEngine/SessionTasks/EnumerateSourceFilesSessionTask.cs
@@ -111,7 +111,7 @@ internal sealed class EnumerateSourceFilesSessionTask : SessionTask<List<SourceF
     }
 
     private void ParseSourceFile(SourceFile sourceFile,
-                                 IReadOnlyList<COFFGroup> coffGroups)
+                                 List<COFFGroup> coffGroups)
     {
         foreach (var compilandUsingThisSourceFile in sourceFile._compilands)
         {

--- a/src/SizeBench.GUI.Packaging/SizeBench.GUI.Packaging.wapproj
+++ b/src/SizeBench.GUI.Packaging/SizeBench.GUI.Packaging.wapproj
@@ -22,7 +22,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>7c2b0ed6-f9b5-47c0-a531-1dd7731b0681</ProjectGuid>
-    <TargetPlatformVersion>10.0.20348.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateAppInstallerFile>false</GenerateAppInstallerFile>

--- a/src/SizeBench.GUI/Pages/TypeLayoutPageViewModel.cs
+++ b/src/SizeBench.GUI/Pages/TypeLayoutPageViewModel.cs
@@ -11,7 +11,7 @@ internal sealed class TypeLayoutPageViewModel : SingleBinaryViewModelBase
     private readonly IUITaskScheduler _uiTaskScheduler;
     private readonly IExcelExporter _excelExporter;
 
-    private IReadOnlyList<TypeLayoutItem> _typeLayoutItems = new List<TypeLayoutItem>();
+    private List<TypeLayoutItem> _typeLayoutItems = new List<TypeLayoutItem>();
     public IReadOnlyList<TypeLayoutItem> TypeLayoutItems
     {
         get => this._typeLayoutItems;


### PR DESCRIPTION
## Why is this change being made?
A customer reported that a binary/PDB they had created with LLD was failing to parse some code block symbols.  It turns out this is because LLD PDBs seem to have some...questionable data in them at times.  As the comment in this PR's code change says, we can end up finding a block that, when we walk up to its parent `SymTagFunction` and parse that function's primary and separated blocks, we do not end up discovering any block with the same symIndexID as the block we started from.

I think this is probably a bug in LLD's PDB generation, but it is straightforward enough to work around in SizeBench.

## Briefly summarize what changed
When we parse a block that causes us to walk up and parse a parent complex function, we still try to look the block up by SymIndexID after since that's the most accurate and works almost all of the time.  But, if that fails, instead of throwing, we now walk through all the blocks in the function to see if any of them fully contain the RVA range of the block we're trying to find - if they do, we go ahead and count that as a successful parse of the block.

While I was fixing this, it seems the .NET SDK has updated and detects a few more warnings with Roslyn.  I'm fixing the to keep things warning-clean.

## How was the change tested?
Manual testing.

I cannot seem to make a minimal repro since it involves a complex binary using LTO and other fancy things that are difficult to attempt in SizeBench's test collateral.  I cannot check in their binary/PDB as it's private, so unfortunately there's no regression coverage for this.

## PR Checklist

* [x] Contributor License Agreement (CLA) has been signed. If not, go [here](https://cla.opensource.microsoft.com/microsoft/WinAppPerf) and sign the CLA
* [x] Changes have been validated
* [ ] ~Documentation updated. Please add or update any docs in the repo as necessary.~